### PR TITLE
review and update missing javadoc for org.jboss.reddeer.junit plugin

### DIFF
--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/configuration/RedDeerConfigurationException.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/configuration/RedDeerConfigurationException.java
@@ -10,10 +10,19 @@ public class RedDeerConfigurationException extends RuntimeException {
 
 	private static final long serialVersionUID = 2832066367510275146L;
 
+	/**
+	 * Constructor
+	 * @param message
+	 * @param cause
+	 */
 	public RedDeerConfigurationException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructor
+	 * @param message
+	 */
 	public RedDeerConfigurationException(String message) {
 		super(message);
 	}

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/annotation/AnnotationsFinder.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/annotation/AnnotationsFinder.java
@@ -17,11 +17,20 @@ public class AnnotationsFinder {
 
 	private Matcher<Annotation> annotationMatcher;
 	
+	/**
+	 * Constructor
+	 * @param annotationMatcher
+	 */
 	public AnnotationsFinder(Matcher<Annotation> annotationMatcher) {
 		super();
 		this.annotationMatcher = annotationMatcher;
 	}
 
+	/**
+	 * 
+	 * @param clazz
+	 * @return List of annotations matching the matcher
+	 */
 	public List<Annotation> find(Class<?> clazz){
 		List<Annotation> annotations = new ArrayList<Annotation>();
 		

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/NullRequirementsConfiguration.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/NullRequirementsConfiguration.java
@@ -18,11 +18,17 @@ public class NullRequirementsConfiguration implements
 	
 	private NullConfigurator voidConfigurator;
 
+	/**
+	 * Constructor
+	 */
 	public NullRequirementsConfiguration() {
 		super();
 		this.voidConfigurator = new NullConfigurator();
 	}
 	
+	/**
+	 * @throws RedDeerConfigurationException
+	 */
 	@Override
 	public void configure(Requirement<?> requirement) {
 		if (requirement instanceof PropertyConfiguration || requirement instanceof CustomConfiguration){

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/NullTestRunConfiguration.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/NullTestRunConfiguration.java
@@ -6,8 +6,6 @@ package org.jboss.reddeer.junit.internal.configuration;
  * @author rhopp
  *
  */
-
-
 public class NullTestRunConfiguration implements TestRunConfiguration {
 
 	private RequirementsConfiguration requirementsConfiguration;
@@ -17,6 +15,9 @@ public class NullTestRunConfiguration implements TestRunConfiguration {
 		return "default";
 	}
 
+	/**
+	 * @return RequirementsConfiguration
+	 */
 	@Override
 	public RequirementsConfiguration getRequirementConfiguration() {
 		if (requirementsConfiguration == null){

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementsConfiguration.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementsConfiguration.java
@@ -8,7 +8,6 @@ import org.jboss.reddeer.junit.requirement.Requirement;
  * @author rhopp
  *
  */
-
 public interface RequirementsConfiguration {
 
 	

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementsConfigurationImpl.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementsConfigurationImpl.java
@@ -36,6 +36,10 @@ public class RequirementsConfigurationImpl implements RequirementsConfiguration{
 		this.customConfigurator = new CustomConfigurator(reader);
 	}
 	
+	/**
+	 * Configures the requirement
+	 * @param requirement
+	 */
 	public void configure(Requirement<?> requirement){
 		getConfigurator(requirement).configure(requirement);
 	}

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/SuiteConfiguration.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/SuiteConfiguration.java
@@ -30,6 +30,10 @@ public class SuiteConfiguration {
 	
     private List<TestRunConfiguration> testRunConfigs;
     
+    /**
+     * 
+     * @return List of test run configurations
+     */
 	public List<TestRunConfiguration> getTestRunConfigurations(){
 		if (testRunConfigs == null){
 			testRunConfigs = findTestRunConfigurations();

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/setter/ConfigurationSetter.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/setter/ConfigurationSetter.java
@@ -17,6 +17,11 @@ import org.jboss.reddeer.junit.requirement.Requirement;
  */
 public class ConfigurationSetter {
 
+	/**
+	 * Sets all properties from configuration to the requirement instance.
+	 * @param requirement
+	 * @param configuration
+	 */
 	public void set(Requirement<?> requirement, PropertyBasedConfiguration configuration){
 		for (Property property : configuration.getProperties()){
 			inject(requirement, property);

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/RequirementAnnotationMatcher.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/RequirementAnnotationMatcher.java
@@ -14,6 +14,10 @@ import org.jboss.reddeer.junit.requirement.Requirement;
  */
 public class RequirementAnnotationMatcher extends TypeSafeMatcher<Annotation> {
 
+	/**
+	 * @param annotation
+	 * @return true if annotation is matched safely
+	 */
 	@Override
 	public boolean matchesSafely(Annotation annotation) {
 		Class<?> enclosingType = annotation.annotationType().getEnclosingClass();

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/Requirements.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/Requirements.java
@@ -18,6 +18,10 @@ public class Requirements implements Requirement<Annotation>, Iterable<Requireme
 	private List<Requirement<?>> requirements;
 	private Logger log = Logger.getLogger(Requirements.class);
 	
+	/**
+	 * Constructor
+	 * @param requirements
+	 */
 	public Requirements(List<Requirement<?>> requirements) {
 		super();
 		if (requirements == null){

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/inject/RequirementsInjector.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/inject/RequirementsInjector.java
@@ -15,6 +15,11 @@ import org.jboss.reddeer.junit.requirement.inject.RequirementInjectionException;
  */
 public class RequirementsInjector {
 
+	/**
+	 * Injects requirements to the test instance.
+	 * @param testInstance
+	 * @param requirements
+	 */
 	public void inject(Object testInstance, Requirements requirements) {
 		for (Field field : testInstance.getClass().getDeclaredFields()) {
 			if (field.isAnnotationPresent(InjectRequirement.class)) {

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/FulfillRequirementsStatement.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/FulfillRequirementsStatement.java
@@ -15,11 +15,19 @@ public class FulfillRequirementsStatement extends Statement {
 	
 	private Requirements requirements;
 	
+	/**
+	 * Constructor
+	 * @param requirements
+	 * @param statement
+	 */
 	public FulfillRequirementsStatement(Requirements requirements, Statement statement) {
 		this.statement = statement;
 		this.requirements = requirements;
 	}
 	
+	/**
+	 * Fulfills the requirements and calls {@link #evaluate()} on the provided statement. 
+	 */
 	@Override
 	public void evaluate() throws Throwable {
 		requirements.fulfill();

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
@@ -24,6 +24,12 @@ public class RequirementsRunner extends BlockJUnit4ClassRunner {
 
 	private RequirementsInjector requirementsInjector = new RequirementsInjector();
 	
+	/**
+	 * Constructor
+	 * @param clazz
+	 * @param requirements
+	 * @throws InitializationError
+	 */
 	public RequirementsRunner(Class<?> clazz, Requirements requirements) throws InitializationError {
 		super(clazz);
 		this.requirements = requirements;

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
@@ -26,6 +26,11 @@ public class RequirementsRunnerBuilder extends RunnerBuilder {
 		this.config = config;
 	}
 
+	/**
+	 * Checks if the requirements on the test class can be fulfilled and creates a runner for the test class
+	 * @return runner for the test class
+	 * @throws Throwable
+	 */
 	@Override
 	public Runner runnerForClass(Class<?> clazz) throws Throwable {
 		log.info("Found test " + clazz);

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/Requirement.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/Requirement.java
@@ -12,8 +12,15 @@ import java.lang.annotation.Annotation;
  */
 public interface Requirement<T extends Annotation> {
 	
+	/**
+	 * Check if the requirement can be fullfiled
+	 * @return true if the requirement can be fullfiled, false otherwise
+	 */
 	boolean canFulfill();
 
+	/**
+	 * Fullfill the requirement
+	 */
 	void fulfill();
 	
 	void setDeclaration(T declaration);

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/RequirementException.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/RequirementException.java
@@ -10,10 +10,19 @@ public class RequirementException extends RuntimeException {
 
 	private static final long serialVersionUID = 8655257087643600787L;
 
+	/**
+	 * Constructor
+	 * @param message
+	 * @param cause
+	 */
 	public RequirementException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructor
+	 * @param message
+	 */
 	public RequirementException(String message) {
 		super(message);
 	}

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/inject/RequirementInjectionException.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/inject/RequirementInjectionException.java
@@ -10,10 +10,19 @@ public class RequirementInjectionException extends RuntimeException {
 
 	private static final long serialVersionUID = -2739126612283805953L;
 
+	/**
+	 * Constructor
+	 * @param message
+	 * @param cause
+	 */
 	public RequirementInjectionException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructor
+	 * @param message
+	 */
 	public RequirementInjectionException(String message) {
 		super(message);
 	}

--- a/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuiteException.java
+++ b/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuiteException.java
@@ -10,10 +10,19 @@ public class RedDeerSuiteException extends RuntimeException {
 
 	private static final long serialVersionUID = 4399019522052308797L;
 
+	/**
+	 * Constructor
+	 * @param message
+	 * @param cause
+	 */
 	public RedDeerSuiteException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Constructor
+	 * @param message
+	 */
 	public RedDeerSuiteException(String message) {
 		super(message);
 	}


### PR DESCRIPTION
Review and update missing javadoc

all public members (classes, methods, etc.) should contains javadoc
user should be able able to understand behaviour from description without analyzing the code
use since (for example since 0.5 means <0.5-snapshot...0.6)
use deprecated with referencing the replacement