### PR TITLE
ServerExists condition is not calling open() on ServersView

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ServerExists.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ServerExists.java
@@ -26,7 +26,9 @@ public class ServerExists implements WaitCondition {
 	@Override
 	public boolean test() {
 		try{
-			new ServersView().getServer(this.name);
+			ServersView serversView = new ServersView();
+			serversView.open();
+			serversView.getServer(this.name);
 			return true;
 		} catch (EclipseLayerException ele){
 			return false;


### PR DESCRIPTION
ServerExists condition is not calling open() method on ServersView. This causes this condition to throw exception.

https://github.com/jboss-reddeer/reddeer/blob/848398c1ddfdf4e054388a7bf1901d289cd7dfbc/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/ServerExists.java#L29