### PR TITLE
apodhrad_NPE when creating new RedDeer Test launcher

### DIFF
--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/launcher/RedDeerJUnitTab.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/launcher/RedDeerJUnitTab.java
@@ -88,11 +88,7 @@ public class RedDeerJUnitTab extends AbstractLaunchConfigurationTab {
 
 	@Override
 	public void setDefaults(ILaunchConfigurationWorkingCopy config) {
-		RedDeerLauncherProperties[] currentInput = (RedDeerLauncherProperties[]) propertiesViewer.getInput();
-		for (RedDeerLauncherProperties property : currentInput){
-			property.setDefaults(config);
-		}
-		propertiesViewer.refresh();
+		// no need to set defaults to config, table is initialized with right values
 	}
 
 	@Override


### PR DESCRIPTION
1. Run > Run Configurations ...
2. Select RedDeer Test
3. Press New launch configuration

Then, the following error occurs in error log

java.lang.NullPointerException
	at org.jboss.reddeer.eclipse.ui.launcher.RedDeerJUnitTab.setDefaults(RedDeerJUnitTab.java:91)
	at org.eclipse.debug.internal.ui.launchConfigurations.LaunchConfigurationTabGroupWrapper.setDefaults(LaunchConfigurationTabGroupWrapper.java:255)
	at org.eclipse.debug.internal.ui.launchConfigurations.CreateLaunchConfigurationAction.performAction(CreateLaunchConfigurationAction.java:80)
	at org.eclipse.debug.internal.ui.launchConfigurations.AbstractLaunchConfigurationAction$1.run(AbstractLaunchConfigurationAction.java:107)