### PR TITLE
ljelinko_Refactor ToolItemsLookup to search in whole view.

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/toolbar/ViewToolItem.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/toolbar/ViewToolItem.java
@@ -7,8 +7,11 @@ import org.hamcrest.Matcher;
  * active View ToolBar. </p> If no View is active, exception is thrown.
  * 
  * @author Jiri Peterka
+ * @deprecated Now it's possible to use just {@link DefaultToolItem} when the desired View is active.
  *
  */
+
+@Deprecated
 public class ViewToolItem extends DefaultToolItem {
 
 	/**

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/ToolItemLookup.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/ToolItemLookup.java
@@ -2,9 +2,13 @@ package org.jboss.reddeer.swt.lookup;
 
 import java.util.List;
 
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.hamcrest.Matcher;
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.swt.exception.Thrower;
 import org.jboss.reddeer.swt.impl.shell.WorkbenchShell;
 import org.jboss.reddeer.swt.reference.ReferencedComposite;
@@ -19,6 +23,9 @@ import org.jboss.reddeer.swt.util.ResultRunnable;
  */
 
 public class ToolItemLookup {
+	
+	
+	private static final Logger logger = Logger.getLogger(ToolItemLookup.class);
 
 	private static ToolItemLookup instance = new ToolItemLookup();
 
@@ -47,7 +54,11 @@ public class ToolItemLookup {
 
 	public ToolItem getToolItem(ReferencedComposite rc, int index,
 			Matcher<?>... matchers) {
-		return WidgetLookup.getInstance().activeWidget(rc, ToolItem.class, 0,
+		
+		if (rc == null){
+			rc = findReferencedComposite();
+		}
+		return WidgetLookup.getInstance().activeWidget(rc, ToolItem.class, index,
 				matchers);
 	}
 
@@ -69,5 +80,46 @@ public class ToolItemLookup {
 		}
 		return null;
 	}
+	
+	protected ReferencedComposite findReferencedComposite(){
+		Control control = null;
+		Control activeWidgetParentControl = WidgetLookup.getInstance().getActiveWidgetParentControl();
+		if (activeWidgetParentControl instanceof Shell){
+			control = activeWidgetParentControl;
+		}else{
+			control = getWorkbenchControl(activeWidgetParentControl);
+		}	
+		return new GenericReferencedComposite(control);
+	}
 
+	private Control getWorkbenchControl(final Control activeWorkbenchPartReference) {
+		Control control = Display.syncExec(new ResultRunnable<Control>() {
+
+			@Override
+			public Control run() {
+				Control control = activeWorkbenchPartReference;
+				while (!((control instanceof CTabFolder) || (control instanceof Shell))) {
+										control = control.getParent();
+									}
+				return control;
+			}
+		});
+		return control;
+	}
+	
+	protected class GenericReferencedComposite implements ReferencedComposite{
+		
+		private Control control;
+		
+		public GenericReferencedComposite(Control control) {
+			this.control = control;
+		}
+		
+		@Override
+		public Control getControl() {
+			return control;
+		}
+		
+	}
+	
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetLookup.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetLookup.java
@@ -152,7 +152,7 @@ public class WidgetLookup {
 		return control;
 	}
 
-	private Shell getShellForActiveWorkbench(IWorkbenchPartReference workbenchReference) {
+	protected Shell getShellForActiveWorkbench(IWorkbenchPartReference workbenchReference) {
 		if (workbenchReference == null) {
 			return null;
 		}

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetResolver.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/lookup/WidgetResolver.java
@@ -147,8 +147,10 @@ public class WidgetResolver  {
 			if (control != null) children.add(control);
 			
 		} else if (w instanceof CTabFolder) {
-			Widget[] items = ((CTabFolder) w).getItems();
-			children = Arrays.asList(items);
+			List<Widget> tempList = new ArrayList<>();
+			tempList.addAll(Arrays.asList(((CTabFolder) w).getChildren()));
+			tempList.addAll(Arrays.asList(((CTabFolder) w).getItems()));
+			children = tempList;
 
 		} else if (w instanceof TabFolder) {
 			Widget[] items = ((TabFolder) w).getItems();

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/ToolBarTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/ToolBarTest.java
@@ -72,13 +72,13 @@ public class ToolBarTest {
 
 	@Test
 	public void testToolItemInViewToolBarFound() {
-		ToolItem i = new ViewToolItem("RedDeer SWT ViewToolItem");
+		ToolItem i = new DefaultToolItem("RedDeer SWT ViewToolItem");
 		assertEquals("RedDeer SWT ViewToolItem", i.getToolTipText());
 	}
 
 	@Test
 	public void testToolItemInViewToolBarClicked() {
-		ToolItem i = new ViewToolItem("RedDeer SWT ViewToolItem");
+		ToolItem i = new DefaultToolItem("RedDeer SWT ViewToolItem");
 		i.click();		
 		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());		
 	}
@@ -87,7 +87,7 @@ public class ToolBarTest {
 	public void testToolItemInViewToolBarRegexClicked() {
 		WithTooltipTextMatcher rm = new WithTooltipTextMatcher(
 				new RegexMatcher("RedDeer SWT View.*"));
-		ToolItem i = new ViewToolItem(rm);
+		ToolItem i = new DefaultToolItem(rm);
 		i.click();
 		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());		
 	}

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolitem/ToolItemTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolitem/ToolItemTest.java
@@ -53,8 +53,8 @@ public class ToolItemTest extends SWTLayerTestCase{
 	@Test
 	public void constructorWithIndex() {
 		DefaultToolItem ti = new DefaultToolItem(2);
-		assertTrue("Item has \"PUSH tooltip\" as a tooltip", ti
-				.getToolTipText().equals(TOOLTIP));
+		assertTrue("Item has \"PUSH tooltip tb2\" as a tooltip", ti
+				.getToolTipText().equals(TOOLTIP + " tb2"));
 		assertFalse("Item has not \"" + TOOLTIP + "2\" as a tooltip", ti
 				.getToolTipText().equals(TOOLTIP + "2"));
 	}


### PR DESCRIPTION
Currently, when some view is active and new DefaultToolItem() constructor without ReferencedComposite constructor is called, RedDeer attempts to search for that ToolItem INSIDE active view.

This issue should solve problem, when one wants to search for ToolItems even in active view's toolbars.

When this issue is solved, one shoud be able to create some code like this:
```
new ServersView().open();
new DefaultToolItem("Start the server").click;
```