### PR TITLE
Fix RedDeer IDE startup bug

### DIFF
--- a/product/org.jboss.reddeer.product
+++ b/product/org.jboss.reddeer.product
@@ -20,9 +20,13 @@ org.eclipse.jdt.ui.JavaPerspective
       </programArgs>
       <vmArgs>-Dorg.eclipse.swt.browser.DefaultType=mozilla
 -Dosgi.requiredJavaVersion=1.6
+-Dosgi.configuration.area.default=null
+-Dosgi.user.area.default=null
+-Dosgi.user.area=@user.home
+-Dosgi.instance.area.default=@user.home/workspace
 -XX:MaxPermSize=256m
--Xms40m
--Xmx512m
+-Xms512m
+-Xmx1024m
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>


### PR DESCRIPTION
The following error occurs when IDE starts up

java.lang.ClassCastException: org.eclipse.osgi.internal.framework.EquinoxConfiguration$1 cannot be cast to java.lang.String
	at org.eclipse.m2e.logback.configuration.LogHelper.logJavaProperties(LogHelper.java:26)
	at org.eclipse.m2e.logback.configuration.LogPlugin.loadConfiguration(LogPlugin.java:189)
	at org.eclipse.m2e.logback.configuration.LogPlugin.configureLogback(LogPlugin.java:144)
	at org.eclipse.m2e.logback.configuration.LogPlugin.access$2(LogPlugin.java:107)
	at org.eclipse.m2e.logback.configuration.LogPlugin$1.run(LogPlugin.java:62)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)