### PR TITLE
Fix warnings during building reddeer project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
 		<tychoExtrasVersion>${tycho-version}</tychoExtrasVersion>
 		<eclipse-target-site>http://download.eclipse.org/releases/luna</eclipse-target-site>
 		<swtbot-update-site>http://download.eclipse.org/technology/swtbot/releases/2.2.1</swtbot-update-site>
+		<download-plugin-version>1.2.1</download-plugin-version>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	
 	<modules>

--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -111,7 +111,8 @@
 			</plugin>
 	<plugin>
 		<groupId>com.googlecode.maven-download-plugin</groupId>
-		<artifactId>maven-download-plugin</artifactId>
+		<artifactId>download-maven-plugin</artifactId>
+		<version>${download-plugin-version}</version>
 		<executions>
 			<execution>
 				<id>install-h2-driver</id>

--- a/tests/org.jboss.reddeer.requirements.test/pom.xml
+++ b/tests/org.jboss.reddeer.requirements.test/pom.xml
@@ -76,7 +76,8 @@
 			</plugin>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>
-				<artifactId>maven-download-plugin</artifactId>
+				<artifactId>download-maven-plugin</artifactId>
+				<version>${download-plugin-version}</version>
 				<executions>
 					<execution>
 						<id>install-apache-tomcat-7</id>


### PR DESCRIPTION
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jboss.reddeer:org.jboss.reddeer.eclipse.test:eclipse-test-plugin:0.7.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for com.googlecode.maven-download-plugin:maven-download-plugin is missing. @ line 112, column 10
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jboss.reddeer:org.jboss.reddeer.requirements.test:eclipse-test-plugin:0.7.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for com.googlecode.maven-download-plugin:maven-download-plugin is missing. @ line 77, column 12
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 