### PR TITLE
BrowserEditor can be created with any editor.

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.wst.server.core,
  org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
  org.jboss.reddeer.direct;bundle-version="[0.7,0.8)",
- org.eclipse.core.resources
+ org.eclipse.core.resources,
+ org.eclipse.ui.browser
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.reddeer.eclipse,

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserEditor.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/browser/BrowserEditor.java
@@ -1,13 +1,20 @@
 package org.jboss.reddeer.eclipse.ui.browser;
 
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.internal.browser.WebBrowserEditor;
+import org.hamcrest.Description;
 import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.jboss.reddeer.eclipse.condition.BrowserHasURL;
 import org.jboss.reddeer.swt.condition.PageIsLoaded;
 import org.jboss.reddeer.swt.impl.browser.InternalBrowser;
+import org.jboss.reddeer.swt.matcher.MatcherBuilder;
+import org.jboss.reddeer.swt.matcher.WithTextMatcher;
 import org.jboss.reddeer.swt.wait.TimePeriod;
 import org.jboss.reddeer.swt.wait.WaitUntil;
 import org.jboss.reddeer.swt.wait.WaitWhile;
 import org.jboss.reddeer.workbench.impl.editor.AbstractEditor;
+import org.jboss.reddeer.workbench.matcher.EditorPartTitleMatcher;
 
 /**
  * Represents a browser editor.
@@ -23,8 +30,7 @@ public class BrowserEditor extends AbstractEditor{
 	 * @param title Title
 	 */
 	public BrowserEditor(String title){
-		super(title);
-		browser = new InternalBrowser();
+		this(new WithTextMatcher(title));
 	}
 	
 	/**
@@ -32,8 +38,9 @@ public class BrowserEditor extends AbstractEditor{
 	 * 
 	 * @param titleMatcher Title matcher
 	 */
+	@SuppressWarnings("unchecked")
 	public BrowserEditor(Matcher<String> titleMatcher){
-		super(titleMatcher);
+		super(createBrowserEditorMatchers(titleMatcher));
 		browser = new InternalBrowser();
 	}
 	
@@ -93,4 +100,25 @@ public class BrowserEditor extends AbstractEditor{
 		return browser.getText();
 	}
 
+	@SuppressWarnings("rawtypes")
+	private static Matcher[] createBrowserEditorMatchers(Matcher<String> titleMatcher){ 
+		Matcher[] matchers = MatcherBuilder.getInstance().addMatcher(new Matcher[0], new BrowserEditorMatcher());
+		matchers = MatcherBuilder.getInstance().addMatcher(matchers, new EditorPartTitleMatcher(titleMatcher));
+		return matchers;
+	}
+	
+	private static class BrowserEditorMatcher extends TypeSafeMatcher<IEditorPart>{
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("Editor is of type WebBrowserEditor");
+		}
+
+		@Override
+		protected boolean matchesSafely(IEditorPart item) {
+			return (item instanceof WebBrowserEditor); 
+		}
+		
+	}
+	
 }

--- a/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -27,4 +27,5 @@ Export-Package: org.jboss.reddeer.workbench,
  org.jboss.reddeer.workbench.impl.editor,
  org.jboss.reddeer.workbench.impl.view,
  org.jboss.reddeer.workbench.lookup,
+ org.jboss.reddeer.workbench.matcher,
  org.jboss.reddeer.workbench.preference


### PR DESCRIPTION
This will fail, because not every editor has InternalBrowser in it.
Solution is to ensure, that the editor is org.eclipse.ui.internal.browser.WebBrowserEditor