### PR TITLE
rawagner_AbstractExplorerItem doesnt provide diagnostic info when exception is thrown

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/core/resources/AbstractExplorerItem.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/core/resources/AbstractExplorerItem.java
@@ -3,6 +3,7 @@ package org.jboss.reddeer.eclipse.core.resources;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.jface.exception.JFaceLayerException;
 import org.jboss.reddeer.jface.viewer.handler.TreeViewerHandler;
@@ -24,6 +25,8 @@ import org.jboss.reddeer.workbench.handler.WorkbenchPartHandler;
  */
 public abstract class AbstractExplorerItem {
 
+	protected Logger logger = new Logger(AbstractExplorerItem.class);
+	
 	protected TreeItem treeItem;
 
 	protected TreeViewerHandler treeViewerHandler = TreeViewerHandler
@@ -146,6 +149,12 @@ public abstract class AbstractExplorerItem {
 					item = treeViewerHandler.getTreeItem(item, pathSegment);
 				} catch (JFaceLayerException exception) {
 					// non existing item
+					logger.debug("Obtaining direct children on the current level");
+					List<TreeItem> items = item.getItems();
+					logger.debug("Item \"" + pathSegment + "\" was not found. Available items on the current level:");
+					for (TreeItem treeItem: items) {
+						logger.debug("\"" + treeItem.getText() + "\"");
+					}
 					throw new EclipseLayerException(
 							"Cannot get project item specified by path."
 									+ "Project item either does not exist or solution is ambiguous because "


### PR DESCRIPTION
when calling getProjectItem() and item is not found, exception should contain info about items which project contains. Same as Tree does when searching for some items.