### PR TITLE
dev_Create annotation @RunIf for conditional test execution

### DIFF
--- a/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -18,6 +18,8 @@ Bundle-ClassPath: .,
  lib/commons-beanutils-core-1.8.3.jar,
  lib/ScreenRecorder.jar
 Export-Package: org.jboss.reddeer.junit,
+ org.jboss.reddeer.junit.execution,
+ org.jboss.reddeer.junit.execution.annotation,
  org.jboss.reddeer.junit.extensionpoint,
  org.jboss.reddeer.junit.internal.configuration;x-friends:="org.jboss.reddeer.requirements.test",
  org.jboss.reddeer.junit.internal.requirement;x-friends:="org.jboss.reddeer.requirements.test",

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/execution/TestMethodShouldRun.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/execution/TestMethodShouldRun.java
@@ -1,0 +1,21 @@
+package org.jboss.reddeer.junit.execution;
+
+import org.junit.runners.model.FrameworkMethod;
+
+
+/**
+ * Used to decide whether a specific test method should run or not. 
+ * 
+ * @author mlabuda@redhat.com
+ * @since 0.7
+ */
+public interface TestMethodShouldRun {
+	
+	/**
+	 * Method of conditional running of a test method(s). If condition is met, test method runs.
+	 * 
+	 * @param method framework method which contains conditional running annotation
+	 * @return true if a specified test should run, false otherwise.
+	 */
+	public boolean shouldRun(FrameworkMethod method);
+}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/execution/annotation/RunIf.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/execution/annotation/RunIf.java
@@ -1,0 +1,15 @@
+package org.jboss.reddeer.junit.execution.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jboss.reddeer.junit.execution.TestMethodShouldRun;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RunIf {
+	Class<? extends TestMethodShouldRun> conditionClass();
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/ExecutionTestRedDeerSuite.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/ExecutionTestRedDeerSuite.java
@@ -1,0 +1,57 @@
+package org.jboss.reddeer.junit.execution;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.reddeer.junit.extensionpoint.IAfterTest;
+import org.jboss.reddeer.junit.extensionpoint.IBeforeTest;
+import org.jboss.reddeer.junit.internal.configuration.NullTestRunConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
+import org.jboss.reddeer.junit.internal.runner.EmptySuite;
+import org.jboss.reddeer.junit.internal.runner.NamedSuite;
+import org.jboss.reddeer.junit.internal.runner.RequirementsRunnerBuilder;
+import org.jboss.reddeer.junit.internal.runner.TestsExecutionManager;
+import org.jboss.reddeer.junit.internal.runner.TestsWithoutExecutionSuite;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunListener;
+import org.junit.runners.Suite;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+
+public class ExecutionTestRedDeerSuite extends Suite {
+
+	protected static RunListener[] runListeners;
+	
+	public ExecutionTestRedDeerSuite(Class<?> clazz, RunnerBuilder builder)
+			throws InitializationError {
+		this(clazz, builder, new SuiteConfiguration());
+	}
+
+	protected ExecutionTestRedDeerSuite(Class<?> clazz, RunnerBuilder builder,
+			SuiteConfiguration config) throws InitializationError {
+		super(EmptySuite.class, createSuite(clazz, config));
+	}
+
+	protected static List<Runner> createSuite(Class<?> clazz,
+			SuiteConfiguration config) throws InitializationError {
+		TestsExecutionManager testsManager = new TestsExecutionManager();
+		List<Runner> configuredSuites = new ArrayList<Runner>();
+
+		TestRunConfiguration nullTestRunConfig = new NullTestRunConfiguration();
+		configuredSuites.add(new NamedSuite(new Class[] { clazz },
+				new RequirementsRunnerBuilder(nullTestRunConfig, runListeners, new ArrayList<IBeforeTest>(),
+						new ArrayList<IAfterTest>(), testsManager), nullTestRunConfig.getId()));
+
+		if (!testsManager.allTestsAreExecuted()) {
+			configuredSuites.add(new TestsWithoutExecutionSuite(
+					new Class[] { clazz }, testsManager));
+		}
+		return configuredSuites;
+	}
+
+	@Override
+	protected String getName() {
+		return "Execution Test Red Deer Suite";
+	}
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/ShouldNotRun.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/ShouldNotRun.java
@@ -1,0 +1,13 @@
+package org.jboss.reddeer.junit.execution;
+
+import org.junit.runners.model.FrameworkMethod;
+
+public class ShouldNotRun implements TestMethodShouldRun {
+
+	@Override
+	public boolean shouldRun(FrameworkMethod method) {
+		return false;
+	}
+
+	
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/ShouldRun.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/ShouldRun.java
@@ -1,0 +1,12 @@
+package org.jboss.reddeer.junit.execution;
+
+import org.junit.runners.model.FrameworkMethod;
+
+public class ShouldRun implements TestMethodShouldRun {
+
+	@Override
+	public boolean shouldRun(FrameworkMethod method) {
+		return true;
+	}
+
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/TestMethodShouldRunTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/execution/TestMethodShouldRunTest.java
@@ -1,0 +1,49 @@
+package org.jboss.reddeer.junit.execution;
+
+import static org.junit.Assert.fail;
+
+import org.jboss.reddeer.junit.execution.annotation.RunIf;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(ExecutionTestRedDeerSuite.class)
+public class TestMethodShouldRunTest {
+	
+	@Test
+	public void testShouldRun1() {
+		// PASSED
+	}
+	
+	@Test
+	@RunIf(conditionClass=ShouldRun.class)
+	public void testShouldRun2() {
+		// PASSED
+	}
+	
+	@Test
+	@RunIf(conditionClass=ShouldNotRun.class)
+	public void testShouldNotRun1() {
+		fail("Test was not supposed to run because run if condition was not met.");
+	}
+	
+	@Test
+	@Ignore
+	public void testShouldNotRun2() {
+		fail("Test was not supposed to run because @Ignore annotation is presented.");
+	}
+	
+	@Test
+	@RunIf(conditionClass=ShouldRun.class)
+	@Ignore
+	public void testShouldNotRun3() {
+		fail("Test was not supposed to run because @Ignore annotation is presented, altough run condition was met.");
+	}
+	
+	@Test
+	@RunIf(conditionClass=ShouldNotRun.class)
+	@Ignore
+	public void testShouldNotRun4() {
+		fail("Test was not supposed to run because @Ignore annotation is presented and run condition was not met.");
+	}
+}


### PR DESCRIPTION
Example:

```java
@Test
@RunIf( <boolean value> )
public void test() {
  ...
}
```

Assume that one test class contains many tests but one test will be executed only if something is fullfilled, e.g. switchyard of version 2.0 introduces 3 new bindings but we still have to test switchyard of version 1.1 (without the 3 new bindings).

I cannot use requirement one for 1.1 and one for 2.0 since one of them always throws an exception.