### PR TITLE
ljelinko_LogView#deleteLog() throws exception when <Delete Log> item is not enabled.

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogView.java
@@ -128,6 +128,10 @@ public class LogView extends WorkbenchView{
 		activate();
 		new DefaultTree().setFocus();
 		Menu cm = new ContextMenu(DELETE_LOG);
+		if (!cm.isEnabled()) {
+			log.debug("Unable to delete log. \"" + DELETE_LOG + "\" menu item is not enabled.");
+			return;
+		}
 		cm.select();
 		new DefaultShell(CONFIRM_DLG);
 		new OkButton().click();

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/log/LogViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/log/LogViewTest.java
@@ -155,6 +155,7 @@ public class LogViewTest {
 		assertFalse("There must be messages", logView.getErrorMessages().isEmpty());
 		logView.deleteLog();				
 		assertTrue("There should be no messages", logView.getErrorMessages().isEmpty());
+		logView.deleteLog(); //https://github.com/jboss-reddeer/reddeer/pull/953
 		logView.restoreLog();				
 		assertTrue("There should be no messages", logView.getErrorMessages().isEmpty());
 	}


### PR DESCRIPTION
This item is not enabled when the log is empty.
I think, that `deleteLog()` method shoud do nothing when log is already emptly.