### PR TITLE
Handle preference page changed/dialog ok

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/preferences/MavenSettingsPreferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/preferences/MavenSettingsPreferencePage.java
@@ -2,11 +2,14 @@ package org.jboss.reddeer.eclipse.m2e.core.ui.preferences;
 
 import org.eclipse.swt.widgets.Control;
 import org.jboss.reddeer.core.condition.JobIsRunning;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.text.DefaultText;
 import org.jboss.reddeer.core.reference.ReferencedComposite;
 import org.jboss.reddeer.core.util.Display;
 import org.jboss.reddeer.core.util.ResultRunnable;
+import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.common.wait.WaitWhile;
@@ -21,8 +24,10 @@ import org.jboss.reddeer.jface.preference.PreferencePage;
 
 public class MavenSettingsPreferencePage extends PreferencePage {
 
+	private static final Logger log = Logger.getLogger(MavenSettingsPreferencePage.class);
 	private static final String UPDATE_SETTINGS = "Update Settings";
 	private static final String REINDEX = "Reindex";
+	private static final String UPDATE_SHELL_TITLE = "Update project required";
 
 	/**
 	 * Construct the preference page with "Maven" > "User Settings".
@@ -94,5 +99,17 @@ public class MavenSettingsPreferencePage extends PreferencePage {
 				}, 1);
 			}
 		});
+	}
+	
+	@Override
+	public void handlePageChange(){
+		new DefaultShell(UPDATE_SHELL_TITLE);
+		new PushButton("Yes").click();
+		new WaitWhile(new JobIsRunning(),TimePeriod.VERY_LONG);
+	}
+
+	@Override
+	public String getPageChangedShellName() {
+		return UPDATE_SHELL_TITLE;
 	}
 }

--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/jface/preference/PreferencePage.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/jface/preference/PreferencePage.java
@@ -1,5 +1,7 @@
 package org.jboss.reddeer.jface.preference;
 
+import java.util.Arrays;
+
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.swt.api.Button;
 import org.jboss.reddeer.swt.impl.button.PushButton;
@@ -65,4 +67,43 @@ public abstract class PreferencePage {
 		log.info("Restore default values in Preferences dialog");
 		b.click();
 	}
+	
+	/**
+	 * This method handles all page changes.
+	 */
+	public void handlePageChange(){
+		
+	}
+	
+	/**
+	 * Helps to determine if PreferencePage#handlePageChange method should be called by PreferenceDialog
+	 * @return title of shell which should be handled by this page
+	 */
+	public String getPageChangedShellName(){
+		return null;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode(path);
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		PreferencePage other = (PreferencePage) obj;
+		if (!Arrays.equals(path, other.path))
+			return false;
+		return true;
+	}
+	
+	
 }

--- a/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -16,7 +16,11 @@ Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.eclipse.jst.ejb.ui,
  org.eclipse.datatools.connectivity.dbdefinition.genericJDBC,
  org.eclipse.datatools.sqltools.sqlscrapbook;bundle-version="1.0.2",
- org.eclipse.datatools.sqltools.result.ui;bundle-version="1.1.3"
+ org.eclipse.datatools.sqltools.result.ui;bundle-version="1.1.3",
+ org.eclipse.m2e.core,
+ org.eclipse.m2e.core.ui,
+ org.eclipse.m2e.archetype.common,
+ org.eclipse.m2e.maven.indexer
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.hamcrest.core


### PR DESCRIPTION
OK or changing page might call some another shell asking for confirmation. We need to handle this - add hook to ok dialog method and listener for tree selection - page should implement what needs to be done to handle another dialog. See also eclipse implementation to see how its handled there (if page has two different methods or just one for both events).