### PR TITLE
Support for STEP type log message

### DIFF
--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/context/ExecutionSetting.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/context/ExecutionSetting.java
@@ -50,6 +50,8 @@ public class ExecutionSetting {
 				addLogMessageType(MessageType.DEBUG);
 			} else if (p.equalsIgnoreCase("INFO")) {
 				addLogMessageType(MessageType.INFO);
+			} else if (p.equalsIgnoreCase("STEP")) {
+				addLogMessageType(MessageType.STEP);				
 			} else if (p.equalsIgnoreCase("ALL")) {
 				setLogMessageFilter(MessageType.ALL);
 				return;

--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/logging/Logger.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/logging/Logger.java
@@ -23,6 +23,7 @@ public class Logger {
 	private static final String info = "INFO";
 	private static final String dump = "DUMP";
 	private static final String fatal = "FATAL";
+	private static final String step = "STEP";
 
 	private Class<? extends Object> loggerClass;
 
@@ -203,6 +204,42 @@ public class Logger {
 	public void fatal(String msg) {
 		print(fatal, msg, MessageType.FATAL);
 	}
+	
+	/**
+	 * Log step message using formatting string and arguments
+	 * 
+	 * This should not be used directly in RedDeer API.
+	 * 
+	 * Step message is strictly intended to be used in tests only to describe
+	 * human readable flow that can be used in issue tracker or for describing
+	 * test flow.
+	 * 
+	 * @param fmtString
+	 *            Formatting string
+	 * @param args
+	 *            Arguments
+	 * @see java.lang.String#format(String, Object...)
+	 */
+	public void step(String fmtString, Object... args) {
+		step(String.format(fmtString, args));
+	}
+
+	/**
+	 * log step message
+	 * 
+	 * This should not be used directly in RedDeer API.
+	 * 
+	 * Step message is strictly intended to be used in tests only to describe
+	 * human readable flow that can be used in issue tracker or for describing
+	 * test flow
+	 * 
+	 * @param msg
+	 *            message
+	 */
+	public void step(String msg) {
+		print(step, msg, MessageType.FATAL);
+	}
+	
 
 	/**
 	 * Log fatal message using formatting string and arguments

--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/logging/MessageType.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/logging/MessageType.java
@@ -15,5 +15,6 @@ public class MessageType {
 	public static final int WARN = 16;
 	public static final int ERROR = 32;
 	public static final int FATAL = 64;
-	public static final int ALL = DUMP | TRACE | DEBUG | INFO | WARN | ERROR | FATAL;
+	public static final int STEP = 128;
+	public static final int ALL = DUMP | TRACE | DEBUG | INFO | WARN | ERROR | FATAL | STEP;
 }


### PR DESCRIPTION
Step message is strictly intended for usage in tests only to describe human readable flow that can be used in issue tracker or for describing test flow

This should not be used directly in RedDeer API.