### PR TITLE
Update RedDeer version to 0.8.0-SNAPSHOT

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -4,7 +4,7 @@
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.reddeer</groupId>
-	<version>0.7.0</version>
+	<version>0.8.0-SNAPSHOT</version>
 	<artifactId>jboss-reddeer-archetype</artifactId>
 	<packaging>maven-archetype</packaging>
 	<name>Red Deer Archetype</name>

--- a/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -7,7 +7,7 @@
       <defaultValue>luna</defaultValue>
     </requiredProperty>
     <requiredProperty key="reddeer_version">
-      <defaultValue>0.7.0</defaultValue>
+      <defaultValue>0.8.0</defaultValue>
     </requiredProperty>
     <requiredProperty key="version">
        <defaultValue>1.0.0-SNAPSHOT</defaultValue>

--- a/features/org.jboss.reddeer.eclipse.feature/feature.xml
+++ b/features/org.jboss.reddeer.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.eclipse.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.eclipse.feature/pom.xml
+++ b/features/org.jboss.reddeer.eclipse.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.examples.feature/feature.xml
+++ b/features/org.jboss.reddeer.examples.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.examples.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.examples.feature/pom.xml
+++ b/features/org.jboss.reddeer.examples.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.graphiti.feature/feature.xml
+++ b/features/org.jboss.reddeer.graphiti.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.graphiti.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.graphiti.feature/pom.xml
+++ b/features/org.jboss.reddeer.graphiti.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.ide.feature/feature.xml
+++ b/features/org.jboss.reddeer.ide.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.ide.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.ide.feature/pom.xml
+++ b/features/org.jboss.reddeer.ide.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.junit.extension.feature/feature.xml
+++ b/features/org.jboss.reddeer.junit.extension.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.junit.extension.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.junit.extension.feature/pom.xml
+++ b/features/org.jboss.reddeer.junit.extension.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.rcp.feature/feature.xml
+++ b/features/org.jboss.reddeer.rcp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.rcp.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.rcp.feature/pom.xml
+++ b/features/org.jboss.reddeer.rcp.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.recorder.feature/feature.xml
+++ b/features/org.jboss.reddeer.recorder.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.recorder.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.recorder.feature/pom.xml
+++ b/features/org.jboss.reddeer.recorder.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.spy.feature/feature.xml
+++ b/features/org.jboss.reddeer.spy.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.spy.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.spy.feature/pom.xml
+++ b/features/org.jboss.reddeer.spy.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.swt.feature/feature.xml
+++ b/features/org.jboss.reddeer.swt.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.swt.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.swt.feature/pom.xml
+++ b/features/org.jboss.reddeer.swt.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.tests.feature/feature.xml
+++ b/features/org.jboss.reddeer.tests.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.tests.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.tests.feature/pom.xml
+++ b/features/org.jboss.reddeer.tests.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.ui.feature/feature.xml
+++ b/features/org.jboss.reddeer.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.ui.feature"
       label="%featureName"
-      version="0.7.0"
+      version="0.8.0.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.ui.feature/pom.xml
+++ b/features/org.jboss.reddeer.ui.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,7 @@
         <parent>
                 <groupId>org.jboss.reddeer</groupId>
                 <artifactId>parent</artifactId>
-                <version>0.7.0</version>
+                <version>0.8.0-SNAPSHOT</version>
         </parent>
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.reddeer.branding/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.branding/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Branding Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.branding;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BundleShape: dir

--- a/plugins/org.jboss.reddeer.branding/pom.xml
+++ b/plugins/org.jboss.reddeer.branding/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.common/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.common/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Common
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.common
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.common.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/plugins/org.jboss.reddeer.common/pom.xml
+++ b/plugins/org.jboss.reddeer.common/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
@@ -3,11 +3,11 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Direct
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.direct
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.direct.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.eclipse.core.resources;bundle-version="3.9.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/plugins/org.jboss.reddeer.direct/pom.xml
+++ b/plugins/org.jboss.reddeer.direct/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -3,21 +3,21 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Eclipse Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.wst.server.ui,
  org.eclipse.ui.console,
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.ui.workbench,
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
  org.eclipse.wst.server.core,
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.direct;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.direct;bundle-version="[0.8,0.9)",
  org.eclipse.core.resources,
  org.eclipse.ui.browser
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.reddeer.eclipse/pom.xml
+++ b/plugins/org.jboss.reddeer.eclipse/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
@@ -3,12 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Examples
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.examples
-Bundle-Version: 0.7.0
-Require-Bundle: org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
+Bundle-Version: 0.8.0.qualifier
+Require-Bundle: org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
  org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/plugins/org.jboss.reddeer.examples/pom.xml
+++ b/plugins/org.jboss.reddeer.examples/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
@@ -3,17 +3,17 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer GEF Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.gef
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.gef;bundle-version="3.9.0",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.reddeer.gef,

--- a/plugins/org.jboss.reddeer.gef/pom.xml
+++ b/plugins/org.jboss.reddeer.gef/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.generator/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.generator/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Code Generator
 Bundle-SymbolicName: org.jboss.reddeer.generator;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.generator.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.swt;bundle-version="0.7.0",
- org.jboss.reddeer.workbench;bundle-version="0.7.0",
- org.jboss.reddeer.recorder;bundle-version="0.7.0",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.recorder;bundle-version="[0.8,0.9)",
  org.eclipse.swtbot.generator;bundle-version="2.2.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.reddeer.generator/pom.xml
+++ b/plugins/org.jboss.reddeer.generator/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.graphiti/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.graphiti/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Graphiti Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.graphiti
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.graphiti.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
@@ -11,12 +11,12 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.graphiti;bundle-version="0.10.0",
  org.eclipse.graphiti.ui;bundle-version="0.10.0",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.gef;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.gef;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.reddeer.graphiti.api,

--- a/plugins/org.jboss.reddeer.graphiti/pom.xml
+++ b/plugins/org.jboss.reddeer.graphiti/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
@@ -3,14 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JFace Componnet
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.reddeer.jface.exception,

--- a/plugins/org.jboss.reddeer.jface/pom.xml
+++ b/plugins/org.jboss.reddeer.jface/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
@@ -3,18 +3,18 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Extensions
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.junit.extension;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.extension.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.apache.commons.logging;bundle-version="1.1.1",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
  

--- a/plugins/org.jboss.reddeer.junit.extension/pom.xml
+++ b/plugins/org.jboss.reddeer.junit.extension/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	
 </project>

--- a/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -3,14 +3,14 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Support
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.junit;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.swt,
  org.junit;bundle-version="4.0.0",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.apache.commons.logging;bundle-version="1.1.1"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/plugins/org.jboss.reddeer.junit/pom.xml
+++ b/plugins/org.jboss.reddeer.junit/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/plugins/org.jboss.reddeer.recorder/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.recorder/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jboss.reddeer.recorder Core Plugin
 Bundle-SymbolicName: org.jboss.reddeer.recorder;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.recorder.core.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.recorder/pom.xml
+++ b/plugins/org.jboss.reddeer.recorder/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
         <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
   <artifactId>org.jboss.reddeer.recorder</artifactId>

--- a/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
@@ -2,18 +2,18 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Reddeer Requirements support
 Bundle-SymbolicName: org.jboss.reddeer.requirements
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat

--- a/plugins/org.jboss.reddeer.requirements/pom.xml
+++ b/plugins/org.jboss.reddeer.requirements/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/plugins/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Selenium Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.selenium
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.redderr.bot.selenium.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/plugins/org.jboss.reddeer.selenium/pom.xml
+++ b/plugins/org.jboss.reddeer.selenium/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
@@ -2,16 +2,16 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Spy
 Bundle-SymbolicName: org.jboss.reddeer.spy;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.spy.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.gef,
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.swt;bundle-version="0.7.0",
- org.jboss.reddeer.workbench;bundle-version="0.7.0",
- org.jboss.reddeer.gef;bundle-version="0.7.0",
- org.jboss.reddeer.common;bundle-version="0.7.0"
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.gef;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: org.jboss.reddeer.spy,

--- a/plugins/org.jboss.reddeer.spy/pom.xml
+++ b/plugins/org.jboss.reddeer.spy/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
@@ -3,12 +3,12 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.Activator
 Require-Bundle: org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.swt,
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.eclipse.core.runtime,
  org.eclipse.ui.forms,
  org.eclipse.ui.workbench,

--- a/plugins/org.jboss.reddeer.swt/pom.xml
+++ b/plugins/org.jboss.reddeer.swt/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer UI Component
 Bundle-SymbolicName: org.jboss.reddeer.ui;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.ui.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
@@ -16,9 +16,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.launching,
  org.eclipse.debug.ui,
  org.eclipse.pde.ui,
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="0.7.0",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.eclipse.core.variables;bundle-version="3.2.800"
 

--- a/plugins/org.jboss.reddeer.ui/pom.xml
+++ b/plugins/org.jboss.reddeer.ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
   </parent>
   
 </project>

--- a/plugins/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Red Deer UI Forms Components
 Bundle-SymbolicName: org.jboss.reddeer.uiforms
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.uiforms.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.ui.forms,
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
  org.hamcrest.core;bundle-version="1.3.0",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.eclipse.ui.forms,
  org.eclipse.swt
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.reddeer.uiforms/pom.xml
+++ b/plugins/org.jboss.reddeer.uiforms/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -3,17 +3,17 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Workbench Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.jface.text;bundle-version="3.8.100",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
  org.eclipse.ui.editors;bundle-version="3.8.100",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.eclipse.core.resources,
  org.eclipse.jdt.ui,
  org.eclipse.ui.workbench

--- a/plugins/org.jboss.reddeer.workbench/pom.xml
+++ b/plugins/org.jboss.reddeer.workbench/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
         <parent>
                 <groupId>org.jboss.reddeer</groupId>
                 <artifactId>parent</artifactId>
-                <version>0.7.0</version>
+                <version>0.8.0-SNAPSHOT</version>
         </parent>
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>parent</artifactId>
 	<name>Red Deer Parent POM File</name>
-	<version>0.7.0</version>
+	<version>0.8.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<properties>

--- a/product/org.jboss.reddeer.product
+++ b/product/org.jboss.reddeer.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="JBoss Red Deer" uid="reddeer-070" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="0.7.0" useFeatures="true" includeLaunchers="true">
+<product name="JBoss Red Deer" uid="reddeer-070" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="0.8.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <text>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.common.test/pom.xml
+++ b/tests/org.jboss.reddeer.common.test/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<build>
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.jboss.reddeer</groupId>
 			<artifactId>org.jboss.reddeer.common</artifactId>
-			<version>0.7.0</version>
+			<version>0.8.0-SNAPSHOT</version>
 			<type>eclipse-plugin</type>
 		</dependency>
 

--- a/tests/org.jboss.reddeer.direct.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.direct.test/META-INF/MANIFEST.MF
@@ -3,20 +3,20 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Direct Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.direct.test;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.direct.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.direct;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.requirements;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit.extension;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.direct;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.requirements;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.reddeer.direct.test

--- a/tests/org.jboss.reddeer.direct.test/pom.xml
+++ b/tests/org.jboss.reddeer.direct.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -3,28 +3,28 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Eclipse Componnet Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse.test;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.jdt.debug.ui,
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
  org.eclipse.wst.server.core,
  org.eclipse.debug.core,
  org.eclipse.ui.views.log,
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
  org.eclipse.ui.browser,
  org.eclipse.jst.ejb.ui,
- org.jboss.reddeer.requirements;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit.extension;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.requirements;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.8,0.9)",
  org.eclipse.datatools.connectivity.dbdefinition.genericJDBC,
- org.jboss.reddeer.gef;bundle-version="[0.7.0,0.8.0)",
- org.jboss.reddeer.uiforms;bundle-version="[0.7.0,0.8.0)"
+ org.jboss.reddeer.gef;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.uiforms;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.hamcrest.core

--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/tests/org.jboss.reddeer.gef.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.gef.test/META-INF/MANIFEST.MF
@@ -3,18 +3,18 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer GEF Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.gef.test
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.test.Activator
 Require-Bundle: org.junit,
  org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.gef;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.requirements;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.gef;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.requirements;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.gef.test/pom.xml
+++ b/tests/org.jboss.reddeer.gef.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.generator.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.generator.test/META-INF/MANIFEST.MF
@@ -3,17 +3,17 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Code Generator Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.generator.test
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.generator.test.Activator
 Require-Bundle: org.junit,
  org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="0.7.0",
- org.jboss.reddeer.junit;bundle-version="[0.7.0,0.8.0)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.generator;bundle-version="[0.7.0,0.8.0)"
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.generator;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.generator.test/pom.xml
+++ b/tests/org.jboss.reddeer.generator.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.graphiti.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.graphiti.test/META-INF/MANIFEST.MF
@@ -3,19 +3,19 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Graphiti Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.graphiti.test
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.graphiti.test.Activator
 Require-Bundle: org.junit,
  org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.gef;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.graphiti;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.requirements;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.gef;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.graphiti;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.requirements;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.graphiti.test/pom.xml
+++ b/tests/org.jboss.reddeer.graphiti.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
@@ -3,15 +3,15 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JFace Componnet Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface.test;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit.extension;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.8,0.9)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.jface.test/pom.xml
+++ b/tests/org.jboss.reddeer.jface.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.junit.test/pom.xml
+++ b/tests/org.jboss.reddeer.junit.test/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<build>
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.jboss.reddeer</groupId>
 			<artifactId>org.jboss.reddeer.junit</artifactId>
-			<version>0.7.0</version>
+			<version>0.8.0-SNAPSHOT</version>
 			<type>eclipse-plugin</type>
 		</dependency>
 
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>org.jboss.reddeer</groupId>
 			<artifactId>org.jboss.reddeer.common</artifactId>
-			<version>0.7.0</version>
+			<version>0.8.0-SNAPSHOT</version>
 			<type>eclipse-plugin</type>
 		</dependency>
 

--- a/tests/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
@@ -2,18 +2,18 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Requirements Test
 Bundle-SymbolicName: org.jboss.reddeer.requirements.test
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
  org.junit;bundle-version="4.10.0",
- org.jboss.reddeer.requirements;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit.extension;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="0.7.0",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)"
+ org.jboss.reddeer.requirements;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.reddeer.requirements.test/pom.xml
+++ b/tests/org.jboss.reddeer.requirements.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/tests/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
@@ -3,21 +3,21 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt.test;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.core.expressions,
  org.eclipse.ui.views.log,
  org.eclipse.m2e.core.ui,
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit.extension;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
  org.jboss.reddeer.requirements
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.swt.test/pom.xml
+++ b/tests/org.jboss.reddeer.swt.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
@@ -2,19 +2,19 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Red Deer UI Forms Components Test
 Bundle-SymbolicName: org.jboss.reddeer.uiforms.test;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.uiforms.test.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.ui.forms,
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.uiforms;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.uiforms;bundle-version="[0.8,0.9)",
  org.hamcrest.core;bundle-version="1.3.0",
  org.junit,
- org.jboss.reddeer.junit.extension;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
  org.eclipse.ui.views.log;bundle-version="1.0.500"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.uiforms.test/pom.xml
+++ b/tests/org.jboss.reddeer.uiforms.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
@@ -3,20 +3,20 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Workbench Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench.test;singleton:=true
-Bundle-Version: 0.7.0
+Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.test.Activator
 Require-Bundle: org.eclipse.ui,
- org.jboss.reddeer.workbench;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.swt;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.workbench;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
  org.eclipse.core.runtime,
  org.junit;bundle-version="4.11.0",
- org.jboss.reddeer.eclipse;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.jface;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.eclipse;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.jface;bundle-version="[0.8,0.9)",
  org.eclipse.jface.text;bundle-version="3.8.100",
- org.jboss.reddeer.junit.extension;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.direct;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.common;bundle-version="[0.7,0.8)",
- org.jboss.reddeer.junit;bundle-version="[0.7,0.8)",
+ org.jboss.reddeer.junit.extension;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.direct;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.common;bundle-version="[0.8,0.9)",
+ org.jboss.reddeer.junit;bundle-version="[0.8,0.9)",
  org.eclipse.jdt
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.workbench.test/pom.xml
+++ b/tests/org.jboss.reddeer.workbench.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.7.0</version>
+		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
         <parent>
                 <groupId>org.jboss.reddeer</groupId>
                 <artifactId>parent</artifactId>
-                <version>0.7.0</version>
+                <version>0.8.0-SNAPSHOT</version>
         </parent>
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
0.7.0 is dead, long live 0.8.0.

This command was used to update the bundle ranges:
find . -iname MANIFEST.MF -ipath '*/META-INF/M*' |xargs perl -pi -e 's/\[0.7,0.8\)/[0.8,0.9)/'