### PR TITLE
DefaultToolItem - some constructor variant doesn't work

### DIFF
--- a/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/impl/section/AbstractSection.java
+++ b/plugins/org.jboss.reddeer.uiforms/src/org/jboss/reddeer/uiforms/impl/section/AbstractSection.java
@@ -22,7 +22,7 @@ public abstract class AbstractSection extends AbstractWidget<org.eclipse.ui.form
 	}
 	
 	public Control getControl() {
-		return swtWidget.getClient();
+		return swtWidget;
 	}
 
 	public String getText() {


### PR DESCRIPTION
![screenshot from 2015-03-23 08 49 20](https://cloud.githubusercontent.com/assets/8044780/6776019/ae2b7826-d139-11e4-9bbb-e8bddf4e839f.png)

For the attached picture, following code should work.
DefaultSection section = new DefaultSection("Event Definitions");
new DefaultToolItem(section, "Edit").click();

But the 'Edit' tool item is not found by this code.
