### PR TITLE
Remove singleton atribute from org.jboss.reddeer.junit

### DIFF
--- a/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Support
 Bundle-Vendor: JBoss by Red Hat
-Bundle-SymbolicName: org.jboss.reddeer.junit;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.junit
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.Activator
 Require-Bundle: org.eclipse.ui,


### PR DESCRIPTION
The reason Vlado defined org.jboss.reddeer.junit is to save
some memory in osgi. But this poses a problem when we then want
to use two or more different RedDeer versions as a dependency on the same
update site - tycho will not allow to build a site that relies on different versions
of a bundle that is defined as a singleton. So we concluded that this is more
important.