### PR TITLE
Remove singleton atribute from RedDeer plugins

### DIFF
--- a/plugins/org.jboss.reddeer.branding/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Branding Component
 Bundle-Vendor: JBoss by Red Hat
-Bundle-SymbolicName: org.jboss.reddeer.branding;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.branding
 Bundle-Version: 0.8.0.qualifier
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.jboss.reddeer.gef.spy/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.gef.spy/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer GEF Spy
-Bundle-SymbolicName: org.jboss.reddeer.gef.spy;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.gef.spy
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.spy.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.reddeer.generator/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.generator/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Code Generator
-Bundle-SymbolicName: org.jboss.reddeer.generator;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.generator
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.generator.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Extensions
 Bundle-Vendor: JBoss by Red Hat
-Bundle-SymbolicName: org.jboss.reddeer.junit.extension;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.junit.extension
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.extension.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Support
 Bundle-Vendor: JBoss by Red Hat
-Bundle-SymbolicName: org.jboss.reddeer.junit;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.junit
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.reddeer.recorder/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.recorder/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jboss.reddeer.recorder Core Plugin
-Bundle-SymbolicName: org.jboss.reddeer.recorder;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.recorder
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.recorder.core.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Spy
-Bundle-SymbolicName: org.jboss.reddeer.spy;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.spy
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.spy.Activator
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer UI Component
-Bundle-SymbolicName: org.jboss.reddeer.ui;singleton:=true
+Bundle-SymbolicName: org.jboss.reddeer.ui
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.jboss.reddeer.ui.Activator
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
The reason we defined some plugins as singletons is to save
some memory in osgi. But this poses a problem when we then want
to use two or more different RedDeer versions as a dependency on the same
update site - tycho will not allow to build a site that relies on different versions
of a bundle that is defined as a singleton. So we concluded that this is more
important.