### PR TITLE
Deprecate swt's Regex and RegexSeq

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/regex/Regex.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/regex/Regex.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 /**
  * Regex pattern class for widgets usage
  * @author Jiri Peterka
- *
+ * @deprecated use matcher
  */
 public class Regex {
 

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/regex/RegexSeq.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/regex/RegexSeq.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 /**
  * Regex list of paterns for widgets usage
  * @author Jiri Peterka
- *
+ * @deprecated use matcher
  */
 public class RegexSeq {
 


### PR DESCRIPTION
It's not used anywhere in reddeer. User can use Matcher