### PR TITLE
Dont save editors when closing

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WorkbenchPartHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WorkbenchPartHandler.java
@@ -236,7 +236,9 @@ public class WorkbenchPartHandler {
 
 	/**
 	 * Closes all editors in active workbench.
+	 * @deprecated use org.jboss.reddeer.workbench.handler.EditorHandler#closeAll()
 	 */
+	@Deprecated
 	public void closeAllEditors() {
 		Display.syncExec(new Runnable() {
 
@@ -246,7 +248,7 @@ public class WorkbenchPartHandler {
 				final IWorkbenchPage activePage = workbench
 						.getActiveWorkbenchWindow().getActivePage();
 
-				activePage.closeEditors(activePage.getEditorReferences(), true);
+				activePage.closeEditors(activePage.getEditorReferences(), false);
 			}
 		});
 	}

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/AbstractExplorerItemTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jdt/ui/AbstractExplorerItemTest.java
@@ -24,9 +24,9 @@ import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.jboss.reddeer.core.condition.JobIsRunning;
-import org.jboss.reddeer.core.handler.WorkbenchPartHandler;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.workbench.handler.EditorHandler;
 import org.jboss.reddeer.workbench.impl.editor.DefaultEditor;
 import org.junit.After;
 import org.junit.Before;
@@ -74,7 +74,7 @@ public abstract class AbstractExplorerItemTest {
 		
 		createJavaClass(JAVA_CLASS_NAME);
 		
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		explorer.getProject(PROJECT_NAME).getProjectItem(projectItemPath).open();
 		assertTrue("Active Editor has to have title " + JAVA_CLASS_FILE_NAME,
 			new DefaultEditor().getTitle().equals(JAVA_CLASS_FILE_NAME));
@@ -86,7 +86,7 @@ public abstract class AbstractExplorerItemTest {
 		project.getProjectItem(PROJECT_ITEM_TEXT).select();
 		
 		createJavaClass(JAVA_CLASS_NAME);
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		explorer.activate();
 		
 		ProjectItem projectItem = project.getProjectItem(projectItemPath);

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/contentoutline/OutlineViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/contentoutline/OutlineViewTest.java
@@ -11,8 +11,8 @@ import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.ui.views.contentoutline.OutlineView;
 import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.workbench.handler.EditorHandler;
 import org.jboss.reddeer.core.exception.CoreLayerException;
-import org.jboss.reddeer.core.handler.WorkbenchPartHandler;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -38,7 +38,7 @@ public class OutlineViewTest{
 	
 	@Test
 	public void testElementsInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();
@@ -47,7 +47,7 @@ public class OutlineViewTest{
 	
 	@Test(expected=CoreLayerException.class)
 	public void testCollapseInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();
@@ -56,7 +56,7 @@ public class OutlineViewTest{
 	
 	@Test(expected=CoreLayerException.class)
 	public void testSortInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();
@@ -65,7 +65,7 @@ public class OutlineViewTest{
 	
 	@Test(expected=CoreLayerException.class)
 	public void testHideFieldsInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();
@@ -74,7 +74,7 @@ public class OutlineViewTest{
 	
 	@Test(expected=CoreLayerException.class)
 	public void testHideStaticFieldsAndMethodsInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();
@@ -83,7 +83,7 @@ public class OutlineViewTest{
 	
 	@Test(expected=CoreLayerException.class)
 	public void testHideNonPublicMembersInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();
@@ -92,7 +92,7 @@ public class OutlineViewTest{
 	
 	@Test(expected=CoreLayerException.class)
 	public void testHideLocalTypesInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();
@@ -101,7 +101,7 @@ public class OutlineViewTest{
 	
 	@Test(expected=CoreLayerException.class)
 	public void testLinkWithEditorInEmptyOutlineView() {
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		
 		outlineView = new OutlineView();
 		outlineView.open();

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
@@ -32,13 +32,13 @@ import org.jboss.reddeer.jface.text.contentassist.ContentAssistant;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.core.handler.ShellHandler;
-import org.jboss.reddeer.core.handler.WorkbenchPartHandler;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.keyboard.KeyboardFactory;
 import org.jboss.reddeer.core.util.Display;
 import org.jboss.reddeer.common.wait.AbstractWait;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.workbench.exception.WorkbenchLayerException;
+import org.jboss.reddeer.workbench.handler.EditorHandler;
 import org.jboss.reddeer.workbench.impl.editor.TextEditor;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -53,7 +53,7 @@ public class TextEditorTest {
 	@BeforeClass
 	public static void setup(){
 		TextEditorTest.importTestProject();
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 		TextEditor javaTextEditor = TextEditorTest.openJavaFile();
 		TextEditorTest.ORIGINAL_JAVA_FILE_TEXT = javaTextEditor.getText();
 		javaTextEditor.close();
@@ -77,7 +77,7 @@ public class TextEditorTest {
 		TextEditor javaTextEditor = TextEditorTest.openJavaFile();
 		javaTextEditor.setText(TextEditorTest.ORIGINAL_JAVA_FILE_TEXT);
 		javaTextEditor.save();
-		WorkbenchPartHandler.getInstance().closeAllEditors();
+		EditorHandler.getInstance().closeAll(true);
 	}
 
 	@Test(expected=WorkbenchLayerException.class)


### PR DESCRIPTION
Currently when calling WorkbenchParHandler.closeAllEditors() we send true to activePage.closeEditors(). This however means, according to eclipse javadoc, that user will be given chance to save editors (which means shell asking for confirmation will popup) - this might result in locking this operation. Safer would be to send false.