### PR TITLE
ModifyModulesPage#getConfiguredModules() doesn't work properly

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ModifyModulesDialogTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/wst/server/ui/view/ModifyModulesDialogTest.java
@@ -91,4 +91,15 @@ public class ModifyModulesDialogTest extends ServersViewTestCase{
 		modules = server.getModules();
 		assertThat(modules.size(), is(0));
 	}
+	
+	@Test
+	public void testRemoveConfiguredModules() {
+		ModifyModulesDialog dialog = server.addAndRemoveModules();
+		ModifyModulesPage page = new ModifyModulesPage();
+		page.add(PROJECT_1, PROJECT_3);
+		if (!page.getConfiguredModules().isEmpty()) {
+		   page.removeAll();
+		}
+		dialog.finish();
+	}
 }


### PR DESCRIPTION
Following code ends with SWTLayerException
```java
ModifyModulesDialog dialog = server.addAndRemoveModules();
ModifyModulesPage page = dialog.getFirstPage();
if (!page.getConfiguredModules().isEmpty()) {
   page.removeAll();
}
dialog.finish();
```

The problem is that #getConfiguredModules() sets focus to table, so when the #removeAll() is called, the button can't be found because the lookup is not performed on the active shell but on the table.

Stack trace:
```
org.jboss.reddeer.swt.exception.SWTLayerException: No matching widget found
	at org.jboss.reddeer.swt.lookup.WidgetLookup.activeWidget(WidgetLookup.java:206)
	at org.jboss.reddeer.swt.lookup.ButtonLookup.getButton(ButtonLookup.java:39)
	at org.jboss.reddeer.swt.impl.button.AbstractButton.<init>(AbstractButton.java:51)
	at org.jboss.reddeer.swt.impl.button.PushButton.<init>(PushButton.java:62)
	at org.jboss.reddeer.swt.impl.button.PushButton.<init>(PushButton.java:19)
	at org.jboss.reddeer.eclipse.wst.server.ui.wizard.ModifyModulesPage.removeAll(ModifyModulesPage.java:57)
```