### PR TITLE
Make look ups and handlers singleton

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/FormTextHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/FormTextHandler.java
@@ -24,6 +24,8 @@ public class FormTextHandler {
 
 	private static FormTextHandler instance;
 
+	private FormTextHandler() { }
+	
 	/**
 	 * Gets instance of FormTextHandler.
 	 * 

--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/TabFolderHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/TabFolderHandler.java
@@ -15,6 +15,8 @@ public class TabFolderHandler {
 
 	private static TabFolderHandler instance;
 
+	private TabFolderHandler() { }
+	
 	/**
 	 * Gets instance of TabItemHandler.
 	 * 

--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/ToolBarLookup.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/ToolBarLookup.java
@@ -35,6 +35,8 @@ public class ToolBarLookup {
 
 	private static ToolBarLookup instance;
 
+	private ToolBarLookup() { }
+	
 	/**
 	 * Gets instance of ToolBarLookup.
 	 * 

--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/ToolItemLookup.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/ToolItemLookup.java
@@ -30,14 +30,19 @@ public class ToolItemLookup {
 	
 	private static final Logger logger = Logger.getLogger(ToolItemLookup.class);
 
-	private static ToolItemLookup instance = new ToolItemLookup();
+	private static ToolItemLookup instance;
 
+	private ToolItemLookup() { }
+	
 	/**
 	 * Gets instance of ToolItemLookup.
 	 * 
 	 * @return ToolItemLookup instance
 	 */
 	public static ToolItemLookup getInstance() {
+		if (instance == null) {
+			instance = new ToolItemLookup();
+		}
 		return instance;
 	}
 

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/progressbar/ProgressBarHandler.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/progressbar/ProgressBarHandler.java
@@ -16,6 +16,7 @@ public class ProgressBarHandler {
 	
 	private static ProgressBarHandler instance;
 	
+	private ProgressBarHandler() { }
 	
 	/**
 	 * Creates and returns instance of ProgressBarHandler class

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/toolbar/ViewToolBar.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/toolbar/ViewToolBar.java
@@ -19,7 +19,7 @@ public class ViewToolBar extends AbstractToolBar {
 	 */
 
 	public ViewToolBar() {
-		ToolBarLookup tl = new ToolBarLookup();
+		ToolBarLookup tl = ToolBarLookup.getInstance();
 		toolBar = tl.getViewToolBar();
 
 	}


### PR DESCRIPTION
some lookups, handlers does not contain private constructor for creating instance and therefore it's possible to create more instances of such classes although it should not be.