### PR TITLE
rev_RedDeer Spy requires Java 8

### DIFF
--- a/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
@@ -13,5 +13,5 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.swt;bundle-version="[0.8,0.9)",
  org.jboss.reddeer.core;bundle-version="[0.8,0.9)",
  org.jboss.reddeer.common;bundle-version="[0.8,0.9)"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Currently, the manifest file in org.jboss.reddeer.spy contains

Bundle-RequiredExecutionEnvironment: JavaSE-1.8

It should be JavaSE-1.7