### PR TITLE
rev_Revise default dependencies for RedDeer test plugin created by wizard

### DIFF
--- a/archetype/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/archetype/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -25,4 +25,6 @@ Require-Bundle: org.junit,
  org.eclipse.equinox.event,
  org.hamcrest.core,
  org.jboss.reddeer.junit${rd_version},
- org.jboss.reddeer.swt${rd_version}
+ org.jboss.reddeer.swt${rd_version},
+ org.jboss.reddeer.core${rd_version},
+ org.jboss.reddeer.workbench${rd_version}

--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/project/_MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/project/_MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: @PLUGIN_VERSION@
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: @PLUGIN_PROVIDER@
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
-Require-Bundle: org.junit, org.jboss.reddeer.junit, org.jboss.reddeer.swt, org.jboss.reddeer.eclipse 
+Require-Bundle: org.junit, org.jboss.reddeer.junit, org.jboss.reddeer.swt, org.jboss.reddeer.core, org.jboss.reddeer.workbench
 


### PR DESCRIPTION
When I create new RedDeer test plugin using wizard (File->New->Other->New RedDeer Test Plug-in), the plug-in has dependencies for org.junit, o.j.r.junit, o.j.r.swt and o.j.r.eclipse.
I would suggest adding at least core and workbench plugins.