### PR TITLE
Cannot run only one test method from Eclipse IDE

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuite.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuite.java
@@ -1,6 +1,5 @@
 package org.jboss.reddeer.junit.runner;
 
-import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -17,10 +16,7 @@ import org.jboss.reddeer.junit.internal.runner.NamedSuite;
 import org.jboss.reddeer.junit.internal.runner.RequirementsRunnerBuilder;
 import org.jboss.reddeer.junit.internal.runner.TestsExecutionManager;
 import org.jboss.reddeer.junit.internal.runner.TestsWithoutExecutionSuite;
-import org.junit.runner.Description;
 import org.junit.runner.Runner;
-import org.junit.runner.manipulation.Filter;
-import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunListener;
 import org.junit.runners.Suite;
 import org.junit.runners.model.InitializationError;
@@ -151,68 +147,4 @@ public class RedDeerSuite extends Suite {
 		return afterTestExts;
 	}
 
-	@Override
-	public void filter(Filter filter) throws NoTestsRemainException {
-		super.filter(new FilterDecorator(filter));
-	}
-
-	/**
-	 * Running single test in case of parameterized test causes issue as explained in
-	 * http://youtrack.jetbrains.com/issue/IDEA-65966
-	 * 
-	 * As a workaround we wrap the original filter and then pass it a wrapped description which removes the parameter
-	 * part (See deparametrizedName).
-	 */
-	private static final class FilterDecorator extends Filter {
-		private final Filter delegate;
-
-		/**
-		 * Constructs the decorator with a given filter.
-		 * 
-		 * @param delegate
-		 *            Filter which will be decorated
-		 */
-		private FilterDecorator(Filter delegate) {
-			this.delegate = delegate;
-		}
-
-		@Override
-		public boolean shouldRun(Description description) {
-			return delegate.shouldRun(wrap(description));
-		}
-
-		@Override
-		public String describe() {
-			return delegate.describe();
-		}
-	}
-
-	/**
-	 * Wraps a given description with a new display name (see deparametrizedName).
-	 * 
-	 * @param description
-	 *            Description
-	 * @return Description with correct display name
-	 */
-	private static Description wrap(Description description) {
-		String name = description.getDisplayName();
-		String fixedName = deparametrizedName(name);
-		Description clonedDescription = Description.createSuiteDescription(fixedName, description.getAnnotations()
-				.toArray(new Annotation[0]));
-		for (Description child : description.getChildren()) {
-			clonedDescription.addChild(wrap(child));
-		}
-		return clonedDescription;
-	}
-
-	/**
-	 * Removes ' default' from a given description name.
-	 * 
-	 * @param name
-	 *            Description name
-	 * @return Description name without ' default'
-	 */
-	private static String deparametrizedName(String name) {
-		return name.replaceAll(" default", "");
-	}
 }

--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/core/RemotePluginTestRunner.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/core/RemotePluginTestRunner.java
@@ -1,5 +1,6 @@
 package org.jboss.reddeer.eclipse.core;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
@@ -7,6 +8,7 @@ import java.util.Locale;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.internal.junit.runner.RemoteTestRunner;
+import org.jboss.reddeer.common.properties.RedDeerProperties;
 import org.osgi.framework.Bundle;
 
 /**
@@ -86,6 +88,8 @@ public class RemotePluginTestRunner extends RemoteTestRunner {
 
 			if (isFlag(args, i, "-loaderpluginname")) //$NON-NLS-1$
 				fLoaderClassLoader = getClassLoader(args[i + 1]);
+			if (isFlag(args, i, "-test")) //$NON-NLS-1$
+				args[i + 1] += getConfigId();
 		}
 
 		if (fTestPluginName == null)
@@ -94,6 +98,24 @@ public class RemotePluginTestRunner extends RemoteTestRunner {
 
 		if (fLoaderClassLoader == null)
 			fLoaderClassLoader = getClass().getClassLoader();
+	}
+	
+	protected String getConfigId() {
+		String locationpath = RedDeerProperties.CONFIG_FILE.getSystemValue();
+		if (locationpath != null) {
+			File location = new File(RedDeerProperties.CONFIG_FILE.getSystemValue());
+			if (!location.exists()) {
+				return "";
+			}
+			if (location.isFile()) {
+				return " " + location.getName();
+			}
+			File[] files = location.listFiles();
+			if (files.length > 0) {
+				return " " + files[0].getName();
+			}
+		}
+		return " default";
 	}
 
 	protected Class loadTestLoaderClass(String className)


### PR DESCRIPTION
Cannot run only one test method from Eclipse IDE when an XML configuration is defined via -Dreddeer.config, this issue is similar to #538 where we remove only "default" configuration.