### PR TITLE
Refactor MarkerIsUpdating condition

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/AbstractExtendedMarkersViewIsUpdating.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/AbstractExtendedMarkersViewIsUpdating.java
@@ -2,26 +2,41 @@ package org.jboss.reddeer.eclipse.condition;
 
 import java.lang.reflect.Method;
 
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.internal.views.markers.ExtendedMarkersView;
-import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.common.condition.WaitCondition;
+import org.jboss.reddeer.core.lookup.WorkbenchPartLookup;
 import org.jboss.reddeer.core.util.Display;
 import org.jboss.reddeer.core.util.ResultRunnable;
+import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
+import org.jboss.reddeer.workbench.impl.view.AbstractView;
 
 /**
- * Returns true if marker based view is updating its UI.
+ * Returns true if marker based view is updating its UI. This is an abstract class and 
+ * its subclasses should specify the concrete view. 
  * 
  * @author Jiri Peterka
  * 
  */
 @SuppressWarnings("restriction")
-public class MarkerIsUpdating implements WaitCondition {
+public abstract class AbstractExtendedMarkersViewIsUpdating implements WaitCondition {
+
+	private ExtendedMarkersView markersView;
 
 	/**
 	 * Construct the condition.
+	 * @param abstractView 
+	 * @param class1 
 	 */
-	public MarkerIsUpdating() {
+	public AbstractExtendedMarkersViewIsUpdating(AbstractView abstractView, final Class<? extends ExtendedMarkersView> viewClass) {
+		abstractView.open();
+		for (IViewPart part : WorkbenchPartLookup.getInstance().getOpenViews()){
+			if (part.getClass().equals(viewClass)){
+				markersView = (ExtendedMarkersView) part;
+				return;
+			}
+		}
+		throw new EclipseLayerException("Cannot find view with the specified class " + viewClass);				
 	}
 
 	@Override
@@ -30,9 +45,6 @@ public class MarkerIsUpdating implements WaitCondition {
 			@Override
 			public Boolean run() {
 				boolean result = false;
-				ExtendedMarkersView markersView = (ExtendedMarkersView) PlatformUI
-						.getWorkbench().getActiveWorkbenchWindow()
-						.getActivePage().getActivePart();
 				try {
 					Method m = ExtendedMarkersView.class.getDeclaredMethod(
 							"isUIUpdating", new Class<?>[0]);

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
@@ -5,14 +5,14 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.hamcrest.Matcher;
-import org.jboss.reddeer.eclipse.condition.MarkerIsUpdating;
+import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitUntil;
+import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.eclipse.condition.AbstractExtendedMarkersViewIsUpdating;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.ui.problems.matcher.AbstractProblemMatcher;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
-import org.jboss.reddeer.common.wait.TimePeriod;
-import org.jboss.reddeer.common.wait.WaitUntil;
-import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 
 /**
@@ -37,8 +37,8 @@ public class ProblemsView extends WorkbenchView{
 	@Deprecated
 	public List<TreeItem> getAllErrors(){
 		activate();
-		new WaitUntil(new MarkerIsUpdating(),TimePeriod.SHORT,false);
-		new WaitWhile(new MarkerIsUpdating());
+		new WaitUntil(new ProblemsViewMarkerIsUpdating(),TimePeriod.SHORT,false);
+		new WaitWhile(new ProblemsViewMarkerIsUpdating());
 		DefaultTree tree = new DefaultTree();
 		return filter(tree.getItems(), true);
 	}
@@ -52,8 +52,8 @@ public class ProblemsView extends WorkbenchView{
 	@Deprecated
 	public List<TreeItem> getAllWarnings(){
 		activate();
-		new WaitUntil(new MarkerIsUpdating(),TimePeriod.SHORT,false);
-		new WaitWhile(new MarkerIsUpdating());
+		new WaitUntil(new ProblemsViewMarkerIsUpdating(),TimePeriod.SHORT,false);
+		new WaitWhile(new ProblemsViewMarkerIsUpdating());
 		DefaultTree tree = new DefaultTree();
 		return filter(tree.getItems(), false);
 	}
@@ -107,8 +107,8 @@ public class ProblemsView extends WorkbenchView{
 	 */
 	public List<Problem> getProblems(ProblemType problemType, AbstractProblemMatcher... matchers) {
 		activate();
-		new WaitUntil(new MarkerIsUpdating(),TimePeriod.SHORT,false);
-		new WaitWhile(new MarkerIsUpdating());
+		new WaitUntil(new ProblemsViewMarkerIsUpdating(),TimePeriod.SHORT,false);
+		new WaitWhile(new ProblemsViewMarkerIsUpdating());
 		DefaultTree tree = new DefaultTree();
 		return filterProblems(problemType, tree.getItems(), matchers);
 	}
@@ -283,5 +283,20 @@ public class ProblemsView extends WorkbenchView{
 	 */
 	public enum ProblemType {
 		WARNING, ERROR, ANY
+	}
+	
+	/**
+	 * Returns true if Problems view marker is updating its UI
+	 * 
+	 */
+	@SuppressWarnings("restriction")
+	private class ProblemsViewMarkerIsUpdating extends AbstractExtendedMarkersViewIsUpdating {
+
+		/**
+		 * Construct the condition.
+		 */
+		public ProblemsViewMarkerIsUpdating() {
+			super(ProblemsView.this, org.eclipse.ui.internal.views.markers.ProblemsView.class);
+		}
 	}
 }


### PR DESCRIPTION
At the moment, the condition uses "active view" but since the condition can run for a long time, some other view (like Console view) can steal the focus. 

Move the resolving of active view to constructor. 