### PR TITLE
Change logLevel property to reddeer.logLevel

### DIFF
--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/properties/RedDeerProperties.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/properties/RedDeerProperties.java
@@ -17,7 +17,7 @@ public enum RedDeerProperties {
 
 	LOG_MESSAGE_FILTER("logMessageFilter", "ALL"),
 	
-	LOG_LEVEL("logLevel", "ALL"),
+	LOG_LEVEL("reddeer.logLevel", "ALL"),
 
 	CLOSE_WELCOME_SCREEN("reddeer.close.welcome.screen", true),
 


### PR DESCRIPTION
When you set logLevel property to WARN in eclipse launcher, the running test will fail with the set of exceptions, the first one is

```
org.osgi.framework.BundleException: Exception in org.eclipse.jem.internal.core.JEMPlugin.start() of bundle org.eclipse.jem.
	at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:792)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.start(BundleContextImpl.java:721)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.startWorker0(EquinoxBundle.java:941)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.startWorker(EquinoxBundle.java:318)
	at org.eclipse.osgi.container.Module.doStart(Module.java:571)
	at org.eclipse.osgi.container.Module.start(Module.java:439)
	at org.eclipse.osgi.framework.util.SecureAction.start(SecureAction.java:454)
	at org.eclipse.osgi.internal.hooks.EclipseLazyStarter.postFindLocalClass(EclipseLazyStarter.java:107)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findLocalClass(ClasspathManager.java:531)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.findLocalClass(ModuleClassLoader.java:324)
	at org.eclipse.osgi.internal.loader.BundleLoader.findLocalClass(BundleLoader.java:327)
	at org.eclipse.osgi.internal.loader.sources.SingleSourcePackage.loadClass(SingleSourcePackage.java:36)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:398)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:352)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:344)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:160)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.eclipse.jst.j2ee.internal.J2EEInit.init(J2EEInit.java:121)
	at org.eclipse.jst.j2ee.commonarchivecore.internal.helpers.ArchiveInit.invokePrereqInits(ArchiveInit.java:65)
	at org.eclipse.jst.j2ee.commonarchivecore.internal.helpers.ArchiveInit.init(ArchiveInit.java:38)
	at org.eclipse.jst.j2ee.internal.plugin.J2EEPlugin.start(J2EEPlugin.java:518)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:771)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:1)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:764)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.start(BundleContextImpl.java:721)
	at org.eclipse.osgi.internal.framework.EquinoxBundle.startWorker0(EquinoxBundle.java:941)
	at org.eclipse.osgi.internal.framework.EquinoxBundle$EquinoxModule.startWorker(EquinoxBundle.java:318)
	at org.eclipse.osgi.container.Module.doStart(Module.java:571)
	at org.eclipse.osgi.container.Module.start(Module.java:439)
	at org.eclipse.osgi.framework.util.SecureAction.start(SecureAction.java:454)
	at org.eclipse.osgi.internal.hooks.EclipseLazyStarter.postFindLocalClass(EclipseLazyStarter.java:107)
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findLocalClass(ClasspathManager.java:531)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.findLocalClass(ModuleClassLoader.java:324)
	at org.eclipse.osgi.internal.loader.BundleLoader.findLocalClass(BundleLoader.java:327)
	at org.eclipse.osgi.internal.loader.sources.SingleSourcePackage.loadClass(SingleSourcePackage.java:36)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:398)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:352)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:344)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:160)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.getDeclaredConstructors0(Native Method)
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:2663)
	at java.lang.Class.getConstructor0(Class.java:3067)
	at java.lang.Class.newInstance(Class.java:408)
	at org.eclipse.core.internal.registry.osgi.RegistryStrategyOSGI.createExecutableExtension(RegistryStrategyOSGI.java:184)
	at org.eclipse.core.internal.registry.ExtensionRegistry.createExecutableExtension(ExtensionRegistry.java:905)
	at org.eclipse.core.internal.registry.ConfigurationElement.createExecutableExtension(ConfigurationElement.java:243)
	at org.eclipse.core.internal.registry.ConfigurationElementHandle.createExecutableExtension(ConfigurationElementHandle.java:55)
	at org.eclipse.wst.server.core.internal.ModuleFactory.getDelegate(ModuleFactory.java:96)
	at org.eclipse.wst.server.core.internal.ModuleFactory.getModules(ModuleFactory.java:140)
	at org.eclipse.wst.server.core.ServerUtil.getModules(ServerUtil.java:98)
	at org.jboss.tools.wtp.server.launchbar.ModuleObjectProvider.resourceChanged(ModuleObjectProvider.java:180)
	at org.jboss.tools.wtp.server.launchbar.ModuleObjectProvider.access$1(ModuleObjectProvider.java:176)
	at org.jboss.tools.wtp.server.launchbar.ModuleObjectProvider$3.visit(ModuleObjectProvider.java:156)
	at org.eclipse.core.internal.events.ResourceDelta.accept(ResourceDelta.java:63)
	at org.eclipse.core.internal.events.ResourceDelta.accept(ResourceDelta.java:74)
	at org.eclipse.core.internal.events.ResourceDelta.accept(ResourceDelta.java:47)
	at org.jboss.tools.wtp.server.launchbar.ModuleObjectProvider.resourceChanged(ModuleObjectProvider.java:151)
	at org.eclipse.core.internal.events.NotificationManager$1.run(NotificationManager.java:299)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.core.internal.events.NotificationManager.notify(NotificationManager.java:289)
	at org.eclipse.core.internal.events.NotificationManager.broadcastChanges(NotificationManager.java:152)
	at org.eclipse.core.internal.resources.Workspace.broadcastPostChange(Workspace.java:373)
	at org.eclipse.core.internal.resources.Workspace.endOperation(Workspace.java:1470)
	at org.eclipse.core.internal.resources.Project.create(Project.java:312)
	at org.eclipse.core.internal.resources.Project.create(Project.java:252)
	at org.eclipse.core.internal.resources.Project.create(Project.java:247)
	at org.eclipse.rse.internal.files.ui.resources.SystemRemoteEditManager.createRemoteEditProject(SystemRemoteEditManager.java:334)
	at org.eclipse.rse.internal.files.ui.resources.SystemRemoteEditManager.getRemoteEditProject(SystemRemoteEditManager.java:284)
	at org.eclipse.rse.internal.files.ui.Activator$InitRemoteEditJob.run(Activator.java:73)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:55)
Caused by: java.lang.IllegalArgumentException: Bad level "WARN"
	at java.util.logging.Level.parse(Level.java:482)
	at org.eclipse.jem.util.logger.proxy.Logger.init(Logger.java:195)
	at org.eclipse.jem.util.logger.proxy.Logger.getLogger(Logger.java:126)
	at org.eclipse.jem.util.logger.proxyrender.EclipseLogger.getEclipseLogger(EclipseLogger.java:89)
	at org.eclipse.jem.util.logger.proxyrender.EclipseLogger.getEclipseLogger(EclipseLogger.java:72)
	at org.eclipse.jem.internal.core.JEMPlugin.start(JEMPlugin.java:50)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:771)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$3.run(BundleContextImpl.java:1)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:764)
	... 71 more
```