### PR TITLE
Change publish url mars -> snapshot

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -90,7 +90,7 @@
 							<artifactItem>
 								<groupId>org.jboss.tools.releng</groupId>		
 								<artifactId>jbosstools-releng-publish</artifactId>
-								<version>${project.version}</version>
+								<version>4.3.0.Beta1-SNAPSHOT</version>
 								<type>tar.gz</type>
 								<outputDirectory>${project.build.directory}/releng-scripts</outputDirectory>	
 							</artifactItem>
@@ -118,7 +118,7 @@
 							<arg>-s</arg>
 							<arg>${project.build.directory}/repository</arg>
 							<arg>-t</arg>
-							<arg>mars/snapshots/builds/${JOB_NAME}/${BUILD_ID}-B${BUILD_NUMBER}/all/repo/</arg>
+							<arg>snapshots/builds/${JOB_NAME}/${BUILD_ID}-B${BUILD_NUMBER}/all/repo/</arg>
 						</arguments>	
 					</configuration>
 				</execution>


### PR DESCRIPTION
It turns out RedDeer is not on mars yet, so
it makes more sense to publish to an url
with luna in it.