### PR TITLE
JBIDE-18772 use consistent path for publishin...
...g snapshot builds

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -12,6 +12,10 @@
 		<version>0.8.0-SNAPSHOT</version>
 	</parent>
 
+	<properties>
+		<publishingPath>mars/snapshots/builds/${JOB_NAME}/${BUILD_ID}-B${BUILD_NUMBER}/all/repo/</publishingPath>
+	</properties>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -118,7 +122,7 @@
 							<arg>-s</arg>
 							<arg>${project.build.directory}/repository</arg>
 							<arg>-t</arg>
-							<arg>snapshots/builds/${JOB_NAME}/${BUILD_ID}-B${BUILD_NUMBER}/all/repo/</arg>
+							<arg>${publishingPath}</arg>
 						</arguments>	
 					</configuration>
 				</execution>


### PR DESCRIPTION
JBIDE-18772 use builds/staging/RedDeer_master/all/repo/ for current Red Deer 0.8.0 nightly builds against Luna; later move to /mars/ path

externalize publishingPath so it can be passed in from Jenkins

since Red Deer now builds on Mars, we can remove the old Luna convention