### PR TITLE
Improve algorithm for find a labeled widget

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
@@ -172,6 +173,22 @@ public class WidgetHandler {
 				Widget parent = ((Control) w).getParent();
 				java.util.List<Widget> children = WidgetResolver.getInstance()
 						.getChildren(parent);
+				// check whether a label is defined using form data layout
+				for (Widget child : children) {
+					if (child instanceof Label || child instanceof CLabel) {
+						Object layoutData = ((Control) child).getLayoutData();
+						if (layoutData instanceof FormData) {
+							FormData formData = (FormData) layoutData;
+							if (formData.right != null && w.equals(formData.right.control)) {
+								if (child instanceof Label) {
+									return ((Label) child).getText();
+								} else if (child instanceof CLabel) {
+									return ((CLabel) child).getText();
+								}
+							}
+						}
+					}
+				}
 				for (int i = 1; i < children.size(); i++) {
 					if (children.get(i) != null && children.get(i).equals(w)) {
 						for (int y = 1; i - y >= 0; y++) {

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
@@ -3,10 +3,13 @@ package org.jboss.reddeer.swt.test.impl.text;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.ISharedImages;
@@ -17,6 +20,7 @@ import org.jboss.reddeer.swt.impl.text.DefaultText;
 import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.swt.test.SWTLayerTestCase;
 import org.jboss.reddeer.swt.test.utils.LabelTestUtils;
+import org.jboss.reddeer.swt.test.utils.LayoutTestUtils;
 import org.jboss.reddeer.swt.test.utils.TextTestUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,6 +78,22 @@ public class LabeledTextTest extends SWTLayerTestCase {
 
 		LabelTestUtils.createCLabel(shell, "Test clabel");
 		TextTestUtils.createText(shell, "Test text4");
+		
+		Composite formContainer = LayoutTestUtils.createFlatFormComposite(shell);
+
+		Text text1 = TextTestUtils.createText(formContainer, "");
+		text1.setText("formtext");
+		text1.setLayoutData(LayoutTestUtils.entryLayoutData());
+		Label label1 = LabelTestUtils.createLabel(formContainer, "");
+		label1.setText("FormLabel");
+		label1.setLayoutData(LayoutTestUtils.labelLayoutData(text1));
+
+		Text text2 = TextTestUtils.createText(formContainer, "");
+		text2.setText("cformtext");
+		text2.setLayoutData(LayoutTestUtils.entryLayoutData(text1));
+		CLabel label2 = LabelTestUtils.createCLabel(formContainer, "");
+		label2.setText("FormCLabel");
+		label2.setLayoutData(LayoutTestUtils.labelLayoutData(text2));
 	}
 	
 	@Test
@@ -86,6 +106,18 @@ public class LabeledTextTest extends SWTLayerTestCase {
 	public void findLabeledTextWithTwoIcons(){
 		new DefaultShell(SHELL_TITLE);
 		assertTrue(new LabeledText("Test label2").getText().equals("Test text2"));
+	}
+	
+	@Test
+	public void findLabeledTextWithFormLabel(){
+		new DefaultShell(SHELL_TITLE);
+		assertEquals("formtext", new LabeledText("FormLabel").getText());
+	}
+
+	@Test
+	public void findLabeledTextWithFormCLabel(){
+		new DefaultShell(SHELL_TITLE);
+		assertEquals("cformtext", new LabeledText("FormCLabel").getText());
 	}
 	
 	@Test

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/utils/LabelTestUtils.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/utils/LabelTestUtils.java
@@ -3,25 +3,25 @@ package org.jboss.reddeer.swt.test.utils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Shell;
 
 public class LabelTestUtils {
 
-	public static Label createLabel(Shell parent, String text){
+	public static Label createLabel(Composite parent, String text){
 		Label swtLabel= new Label(parent, SWT.LEFT);
 		swtLabel.setText(text);
 		swtLabel.setSize(100,30);
 		return swtLabel;
 	}
 
-	public static Label createLabel(Shell parent, String text, Image image){
+	public static Label createLabel(Composite parent, String text, Image image){
 		Label swtLabel= createLabel(parent, text);
 		swtLabel.setImage(image);
 		return swtLabel;
 	}
 	
-	public static CLabel createCLabel(Shell parent, String text){
+	public static CLabel createCLabel(Composite parent, String text){
 		CLabel swtLabel= new CLabel(parent, SWT.LEFT);
 		swtLabel.setText(text);
 		swtLabel.setSize(100,30);

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/utils/LayoutTestUtils.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/utils/LayoutTestUtils.java
@@ -1,0 +1,40 @@
+package org.jboss.reddeer.swt.test.utils;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
+import org.eclipse.swt.layout.FormLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
+public class LayoutTestUtils {
+
+	public static Composite createFlatFormComposite(Composite parent) {
+		Composite composite = new Composite(parent, SWT.NONE);
+		FormLayout layout = new FormLayout();
+		composite.setLayout(layout);
+		return composite;
+	}
+
+	public static FormData entryLayoutData() {
+		return entryLayoutData(null);
+	}
+
+	public static FormData entryLayoutData(Control referenceControl) {
+		FormData data = new FormData();
+		data = new FormData();
+		data.left = new FormAttachment(0, 100);
+		if (referenceControl != null) {
+			data.top = new FormAttachment(referenceControl, 10);
+		}
+		return data;
+	}
+
+	public static FormData labelLayoutData(Control referenceControl) {
+		FormData data = new FormData();
+		data.right = new FormAttachment(referenceControl, -10);
+		data.top = new FormAttachment(referenceControl, 0, SWT.CENTER);
+		return data;
+	}
+
+}

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/utils/TextTestUtils.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/utils/TextTestUtils.java
@@ -1,12 +1,12 @@
 package org.jboss.reddeer.swt.test.utils;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Text;
 
 public class TextTestUtils {
 
-	public static Text createText(final Shell parent, final String initialText){
+	public static Text createText(final Composite parent, final String initialText){
 		final Text text = new Text(parent, SWT.LEFT);
 		text.setSize(200,30);
 		text.setText(initialText);


### PR DESCRIPTION
Current implementation of WidgetHandler.getLabel() doesn't work if a label is added after the widget, possible solution could be to add the following

```java
	@Override
	public boolean matches(Object obj) {
		if (!(obj instanceof Text || obj instanceof Combo)) {
			return false;
		}

		Control control = (Control) obj;
		Control parent = control.getParent();

		java.util.List<Widget> children = WidgetResolver.getInstance().getChildren(parent);
		for (Widget w : children) {
			if (w instanceof Label || w instanceof CLabel) {
				CLabel cLabel = (CLabel) w;
				Object layoutData = cLabel.getLayoutData();
				if (layoutData instanceof FormData) {
					FormData formData = (FormData) layoutData;
					if (control.equals(formData.left.control) || control.equals(formData.right.control)) {
						if (matcher.matches(cLabel.getText())) {
							return true;
						}
					}
				}
			}
		}

		return false;
	}
```