### PR TITLE
GEFSpy View: Error after click on the top tree item

### DIFF
--- a/plugins/org.jboss.reddeer.gef.spy/src/org/jboss/reddeer/gef/spy/view/GEFSpyView.java
+++ b/plugins/org.jboss.reddeer.gef.spy/src/org/jboss/reddeer/gef/spy/view/GEFSpyView.java
@@ -153,7 +153,7 @@ public class GEFSpyView extends ViewPart {
 				Object obj = ((IStructuredSelection) selection).getFirstElement();
 				if (obj instanceof TreeNode) {
 					Object treeObject = ((TreeNode) obj).getValue();
-					if (treeObject instanceof EditPart) {
+					if (treeObject instanceof EditPart && ((EditPart) treeObject).isSelectable()) {
 						EditPartHandler.getInstance().select((EditPart) treeObject);
 					}
 				}


### PR DESCRIPTION
**How to reproduce:**
1. open some GEF editor
2. open GEFSpy view
3. select an item in the view (not the top one)
4. select the top tree item

**Error Log:**
```
eclipse.buildId=unknown
java.version=1.7.0_75
java.vendor=Oracle Corporation
BootLoader constants: OS=linux, ARCH=x86_64, WS=gtk, NL=en_US
Framework arguments:  -product com.jboss.devstudio.core.product
Command-line arguments:  -os linux -ws gtk -arch x86_64 -product com.jboss.devstudio.core.product

org.eclipse.jface
Error
Thu Mar 19 13:44:05 CET 2015
Problems occurred when invoking code from plug-in: "org.eclipse.jface".

org.jboss.reddeer.swt.exception.SWTLayerException: Exception during sync execution in UI thread
	at org.jboss.reddeer.swt.util.Display.syncExec(Display.java:82)
	at org.jboss.reddeer.swt.util.Display.syncExec(Display.java:50)
	at org.jboss.reddeer.gef.handler.EditPartHandler.select(EditPartHandler.java:40)
	at org.jboss.reddeer.spy.view.GEFSpyView$2.selectionChanged(GEFSpyView.java:157)
	at org.eclipse.jface.viewers.Viewer$2.run(Viewer.java:163)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.ui.internal.JFaceUtil$1.run(JFaceUtil.java:50)
	at org.eclipse.jface.util.SafeRunnable.run(SafeRunnable.java:178)
	at org.eclipse.jface.viewers.Viewer.fireSelectionChanged(Viewer.java:160)
	at org.eclipse.jface.viewers.StructuredViewer.updateSelection(StructuredViewer.java:2171)
	at org.eclipse.jface.viewers.StructuredViewer.handleSelect(StructuredViewer.java:1202)
	at org.eclipse.jface.viewers.StructuredViewer$4.widgetSelected(StructuredViewer.java:1231)
	at org.eclipse.jface.util.OpenStrategy.fireSelectionEvent(OpenStrategy.java:242)
	at org.eclipse.jface.util.OpenStrategy.access$4(OpenStrategy.java:236)
	at org.eclipse.jface.util.OpenStrategy$1.handleEvent(OpenStrategy.java:408)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4454)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1388)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:3799)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3409)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$9.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1032)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:148)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:636)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:332)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:579)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:135)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:648)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:603)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1465)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1438)
Caused by: java.lang.IllegalArgumentException: An EditPart has to be selectable (isSelectable() == true) in order to get selected.
	at org.eclipse.core.runtime.Assert.isLegal(Assert.java:63)
	at org.eclipse.gef.editparts.AbstractEditPart.setSelected(AbstractEditPart.java:1060)
	at org.eclipse.gef.SelectionManager.appendSelection(SelectionManager.java:81)
	at org.eclipse.gef.ui.parts.AbstractEditPartViewer.appendSelection(AbstractEditPartViewer.java:190)
	at org.eclipse.graphiti.ui.internal.editor.GraphitiScrollingGraphicalViewer.appendSelection(GraphitiScrollingGraphicalViewer.java:146)
	at org.eclipse.gef.ui.parts.AbstractEditPartViewer.select(AbstractEditPartViewer.java:599)
	at org.eclipse.graphiti.ui.internal.editor.GraphitiScrollingGraphicalViewer.select(GraphitiScrollingGraphicalViewer.java:53)
	at org.jboss.reddeer.gef.handler.EditPartHandler$1.run(EditPartHandler.java:43)
	at org.jboss.reddeer.swt.util.Display$VoidResultRunnable.run(Display.java:184)
	at org.jboss.reddeer.swt.util.Display$VoidResultRunnable.run(Display.java:1)
	at org.jboss.reddeer.swt.util.Display$ErrorHandlingRunnable.run(Display.java:150)
	at org.jboss.reddeer.swt.util.Display.syncExec(Display.java:78)
	... 41 more

```