### PR TITLE
GEFEditor - adding element to subprocess of BPMN2 diagram

### DIFF
--- a/plugins/org.jboss.reddeer.gef/src/org/jboss/reddeer/gef/editor/GEFEditor.java
+++ b/plugins/org.jboss.reddeer.gef/src/org/jboss/reddeer/gef/editor/GEFEditor.java
@@ -1,5 +1,7 @@
 package org.jboss.reddeer.gef.editor;
 
+import java.util.List;
+
 import org.eclipse.gef.EditPart;
 import org.eclipse.gef.EditPartListener;
 import org.eclipse.gef.GraphicalViewer;
@@ -127,7 +129,10 @@ public class GEFEditor extends DefaultEditor implements ReferencedComposite {
 		Display.asyncExec(new Runnable() {
 			@Override
 			public void run() {
-				viewer.getContents().addEditPartListener(viewerListener);
+				List<EditPart> editParts = ViewerHandler.getInstance().getEditParts(viewer);
+				for (EditPart editPart: editParts) {
+					editPart.addEditPartListener(viewerListener);
+				}
 			}
 		});
 

--- a/tests/org.jboss.reddeer.gef.test/src/org/jboss/reddeer/gef/test/GEFEditorTest.java
+++ b/tests/org.jboss.reddeer.gef.test/src/org/jboss/reddeer/gef/test/GEFEditorTest.java
@@ -82,6 +82,9 @@ public class GEFEditorTest {
 
 		gefEditor.addToolFromPalette("HalfAdder", "Canned Parts", 100, 200);
 		gefEditor.addToolFromPalette("FullAdder", "Canned Parts", 200, 200);
+		
+		gefEditor.addToolFromPalette("Flow Container", 100, 200);
+		gefEditor.addToolFromPalette("LED", 105, 205);
 	}
 
 	@Test


### PR DESCRIPTION
There can be nested elements in BPMN2 diagram. Typical example:
StartEvent -> SubProcess -> EndEvent
SubProcess:StartEvent -> SubProcess:ScriptTask -> SubProcess:EndEvent

Method addToolFromPalette() of GEFEditor detects added element, by hanging listener on DiagramShapeEditPart. It is needed, to listener be hanged on direct parent of added element.