### PR TITLE
Mockito dependency not found during installation

### DIFF
--- a/site/pom.xml
+++ b/site/pom.xml
@@ -75,6 +75,29 @@
 					<includePacked>true</includePacked>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.jboss.tools.tycho-plugins</groupId>
+				<artifactId>repository-utils</artifactId>
+				<executions>
+					<execution>
+						<id>generate-facade</id>
+						<phase>package</phase>
+						<goals>
+							<goal>generate-repository-facade</goal>
+						</goals>
+						<configuration>
+							<associateSites>
+								<site>${eclipse-orbit-update-site}</site>
+							</associateSites>
+							<symbols>
+								<update.site.name>eclipse-orbit-update-site</update.site.name>
+								<update.site.description></update.site.description>
+							</symbols>
+							<removeDefaultCategory>true</removeDefaultCategory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	


### PR DESCRIPTION
Cannot complete the install because one or more required items could not be found.
  Software being installed: RedDeer Tests Feature 0.8.0.201507130720 (org.jboss.reddeer.tests.feature.feature.group 0.8.0.201507130720)
  Missing requirement: RedDeer JUnit Component Tests 0.8.0.201507130720 (org.jboss.reddeer.junit.test 0.8.0.201507130720) requires 'bundle org.mockito 1.9.5' but it could not be found
  Cannot satisfy dependency:
    From: RedDeer Tests Feature 0.8.0.201507130720 (org.jboss.reddeer.tests.feature.feature.group 0.8.0.201507130720)
    To: org.jboss.reddeer.junit.test [0.8.0.201507130720]