### PR TITLE
Snippet wiki generator generates new lines every time jenkins job is run

### DIFF
--- a/snippets/src/org/jboss/reddeer/snippet/UpdateDocSnippets.java
+++ b/snippets/src/org/jboss/reddeer/snippet/UpdateDocSnippets.java
@@ -101,7 +101,7 @@ public class UpdateDocSnippets {
 						
 						line = wikiReader.readLine();
 						builder.append("[source code](" + "https://github.com/jboss-reddeer/reddeer/blob/master/" + 
-								partialPath + ")" + System.lineSeparator() + System.lineSeparator());
+								partialPath + ")" + System.lineSeparator());
 						if (line != null && !line.contains("[source code]")) {
 								builder.append(line + System.lineSeparator());
 						} 


### PR DESCRIPTION
For example see Database-Requirement-Extension.md. After each snippet in that file, there are ~40 empty lines.