### PR TITLE
rev_NPE when deactivating CellEditor

### DIFF
--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/jface/viewers/CellEditor.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/jface/viewers/CellEditor.java
@@ -93,7 +93,11 @@ public class CellEditor implements ReferencedComposite {
 
 	@Override
 	public Control getControl() {
-		return getJFaceCellEditor().getControl();
+		org.eclipse.jface.viewers.CellEditor jFaceCellEditor = getJFaceCellEditor();
+		if (jFaceCellEditor == null) {
+			return null;
+		}
+		return jFaceCellEditor.getControl();
 	}
 
 	/**


### PR DESCRIPTION
java.lang.NullPointerException
	at org.jboss.tools.switchyard.reddeer.widget.CellEditor.getControl(CellEditor.java:115)
	at org.jboss.tools.switchyard.reddeer.widget.CellEditor.isActivated(CellEditor.java:92)
	at org.jboss.tools.switchyard.reddeer.widget.CellEditor.deactivate(CellEditor.java:99)
	at org.jboss.tools.switchyard.reddeer.preference.implementation.ImplementationKnowledgePage.addItem(ImplementationKnowledgePage.java:147)
	at org.jboss.tools.switchyard.reddeer.preference.implementation.ImplementationKnowledgePage.addChannel(ImplementationKnowledgePage.java:93)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.checkAdvancedProperties(ImplementationsTest.java:637)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.checkBPMAdvancedProperties(ImplementationsTest.java:624)
	at org.jboss.tools.switchyard.ui.bot.test.ImplementationsTest.addBPMNImplementationWithNewJavaInterfaceTest(ImplementationsTest.java:256)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner$InvokeMethodWithException.evaluate(RequirementsRunner.java:312)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:80)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:127)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:80)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:108)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.junit.runners.Suite.runChild(Suite.java:127)
	at org.junit.runners.Suite.runChild(Suite.java:26)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:675)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.jboss.reddeer.eclipse.core.RemotePluginTestRunner.main(RemotePluginTestRunner.java:56)
	at org.jboss.reddeer.eclipse.core.UITestApplication.runTests(UITestApplication.java:115)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)