### PR TITLE
org.jboss.reddeer.workbench.test.editor.TextEditorTest.setCursorPosition is failing

### DIFF
--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
@@ -40,6 +40,7 @@ import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.workbench.exception.WorkbenchLayerException;
 import org.jboss.reddeer.workbench.handler.EditorHandler;
 import org.jboss.reddeer.workbench.impl.editor.TextEditor;
+import org.jboss.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -52,6 +53,7 @@ public class TextEditorTest {
 	private static final String JAVA_CLASS_FILE_NAME = "JavaClass.java";
 	@BeforeClass
 	public static void setup(){
+		new WorkbenchShell().maximize();
 		TextEditorTest.importTestProject();
 		EditorHandler.getInstance().closeAll(true);
 		TextEditor javaTextEditor = TextEditorTest.openJavaFile();


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_verification_matrix/jdk=sunjdk1.7,label=stable-windows/2091/testReport/junit/org.jboss.reddeer.workbench.test.editor/TextEditorTest/setCursorPosition_default/?


Error Message

Editor doesn't contain expected text at expected position
package test;
public class JavaClass {

 public JavaClass() {
  System.out.println("");
 }

}
Stacktrace

java.lang.AssertionError: Editor doesn't contain expected text at expected position
package test;
public class JavaClass {

	public JavaClass() {
		System.out.println("");
	}

}

	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.jboss.reddeer.workbench.test.editor.TextEditorTest.setCursorPosition(TextEditorTest.java:132)
