### PR TITLE
jpeterka_org.jboss.reddeer.swt.test.impl.menu.ViewMenuTest.testErrorLogMenu failing

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/ShellHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/ShellHandler.java
@@ -149,6 +149,7 @@ public class ShellHandler {
 		do {
 			// first try to close active shell and reload shells list
 			Shell s = getFilteredActiveShell(shells);
+			shells = filterDisposedShells(shells);
 			// if no active shell present close first one
 			if (s == null && shells.size() > 0){
 				s = shells.get(0);
@@ -214,6 +215,16 @@ public class ShellHandler {
 		return shellsToClose;
 	}
 	
+	private List<Shell> filterDisposedShells(List<Shell> shells) {
+		Iterator<Shell> itShell = shells.iterator();
+		while (itShell.hasNext()){
+			if (itShell.next().isDisposed()){
+				itShell.remove();
+			}
+		}
+		return shells;
+	}
+	
 	private Shell getFilteredActiveShell(List<Shell> shells){
 		Shell result = null;
 		
@@ -223,7 +234,7 @@ public class ShellHandler {
 				Iterator<Shell> itShell = shells.iterator();
 				while (itShell.hasNext() && result == null){
 					Shell shell = itShell.next();
-					if (WidgetHandler.getInstance().getText(shell).equals(
+					if (!shell.isDisposed() && WidgetHandler.getInstance().getText(shell).equals(
 							WidgetHandler.getInstance().getText(activeShell))){
 						result = shell;
 					}


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_verification_matrix/jdk=sunjdk1.7,label=stable-linux/2091/testReport/junit/org.jboss.reddeer.swt.test.impl.menu/ViewMenuTest/testErrorLogMenu_default/?

Stacktrace

org.jboss.reddeer.core.exception.CoreLayerException: Exception during sync execution in UI thread
	at org.jboss.reddeer.core.util.Display.syncExec(Display.java:86)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethodUI(ObjectUtil.java:58)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:39)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:23)
	at org.jboss.reddeer.core.handler.WidgetHandler.getText(WidgetHandler.java:147)
	at org.jboss.reddeer.core.handler.ShellHandler.getFilteredActiveShell(ShellHandler.java:226)
	at org.jboss.reddeer.core.handler.ShellHandler.closeAllNonWorbenchShells(ShellHandler.java:151)
	at org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt.runAfterTest(CloseAllShellsExt.java:41)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:129)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.CleanUpRequirementStatement.evaluate(CleanUpRequirementStatement.java:25)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:110)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.jboss.reddeer.core.exception.CoreLayerException: Exception when invoking method public java.lang.String org.eclipse.swt.widgets.Decorations.getText() by reflection
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:70)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:66)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:61)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:159)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3794)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3433)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
Caused by: java.lang.reflect.InvocationTargetException: null
	at sun.reflect.GeneratedMethodAccessor22.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:68)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:66)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:61)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:159)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3794)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3433)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
Caused by: org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4491)
	at org.eclipse.swt.SWT.error(SWT.java:4406)
	at org.eclipse.swt.SWT.error(SWT.java:4377)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:482)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:419)
	at org.eclipse.swt.widgets.Decorations.getText(Decorations.java:439)
	at sun.reflect.GeneratedMethodAccessor22.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:68)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:66)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:61)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:159)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3794)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3433)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
