### PR TITLE
jpeterka_org.jboss.reddeer.eclipse.test.rse.ui.view.SystemTest.delete default

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/RemoteSystemExists.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/condition/RemoteSystemExists.java
@@ -1,8 +1,8 @@
 package org.jboss.reddeer.eclipse.condition;
 
-import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.rse.ui.view.SystemView;
 import org.jboss.reddeer.common.condition.WaitCondition;
+import org.jboss.reddeer.common.exception.RedDeerException;
 
 /**
  * Returns true, if there is remote system with specified name
@@ -28,7 +28,7 @@ public class RemoteSystemExists implements WaitCondition {
 		try{
 			new SystemView().getSystem(this.name);
 			return true;
-		} catch (EclipseLayerException e){
+		} catch (RedDeerException rde){
 			return false;
 		}		
 	}


### PR DESCRIPTION
Please analyze and provide fix for occansional widget is disposed

http://machydra.brq.redhat.com:8080/job/RedDeer_master_matrix/jdk=sunjdk1.7,label=firebird/643/testReport/junit/org.jboss.reddeer.eclipse.test.rse.ui.view/SystemTest/delete_default/?
 Message

Exception during sync execution in UI thread
Stacktrace

org.jboss.reddeer.core.exception.CoreLayerException: Exception during sync execution in UI thread
	at org.jboss.reddeer.core.util.Display.syncExec(Display.java:86)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethodUI(ObjectUtil.java:58)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:39)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:23)
	at org.jboss.reddeer.core.handler.WidgetHandler.getText(WidgetHandler.java:147)
	at org.jboss.reddeer.swt.impl.tree.AbstractTreeItem.getText(AbstractTreeItem.java:52)
	at org.jboss.reddeer.eclipse.rse.ui.view.System.<init>(System.java:35)
	at org.jboss.reddeer.eclipse.rse.ui.view.SystemView.createSystem(SystemView.java:89)
	at org.jboss.reddeer.eclipse.rse.ui.view.SystemView.getSystems(SystemView.java:63)
	at org.jboss.reddeer.eclipse.rse.ui.view.SystemView.getSystem(SystemView.java:75)
	at org.jboss.reddeer.eclipse.condition.RemoteSystemExists.test(RemoteSystemExists.java:29)
	at org.jboss.reddeer.common.wait.WaitWhile.stopWaiting(WaitWhile.java:54)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:108)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:77)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:53)
	at org.jboss.reddeer.common.wait.WaitWhile.<init>(WaitWhile.java:35)
	at org.jboss.reddeer.eclipse.rse.ui.view.System.delete(System.java:111)
	at org.jboss.reddeer.eclipse.test.rse.ui.view.SystemTest.delete(SystemTest.java:47)
Caused by: org.jboss.reddeer.core.exception.CoreLayerException: Exception when invoking method public java.lang.String org.eclipse.swt.widgets.TreeItem.getText() by reflection
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:70)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:66)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:61)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:159)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3794)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3433)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
Caused by: java.lang.reflect.InvocationTargetException: null
	at sun.reflect.GeneratedMethodAccessor41.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:68)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:66)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:61)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:159)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3794)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3433)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
Caused by: org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4491)
	at org.eclipse.swt.SWT.error(SWT.java:4406)
	at org.eclipse.swt.SWT.error(SWT.java:4377)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:482)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:419)
	at org.eclipse.swt.widgets.TreeItem.getText(TreeItem.java:846)
	at sun.reflect.GeneratedMethodAccessor41.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:68)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:66)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:61)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:159)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:3794)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3433)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)