### PR TITLE
org.jboss.reddeer.eclipse.test.ui.views.ResourceNavigatorItemTest.delete failing

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/core/resources/AbstractProject.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/core/resources/AbstractProject.java
@@ -3,7 +3,9 @@ package org.jboss.reddeer.eclipse.core.resources;
 import java.util.List;
 
 import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.common.matcher.RegexMatcher;
 import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.core.matcher.WithTextMatcher;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.swt.api.Shell;
@@ -100,7 +102,7 @@ public abstract class AbstractProject extends ExplorerItem {
 	private Shell handleDeleteResourcesShell(boolean deleteFromFileSystem) {
 		Shell sDeleteResources = null;
 		try {
-			new DefaultShell("Delete Resources");
+			new DefaultShell(new WithTextMatcher(new RegexMatcher("Delete.*")));
 			new CheckBox().toggle(deleteFromFileSystem);
 			sDeleteResources = new DefaultShell();
 		} catch (SWTLayerException swtle) {


### PR DESCRIPTION
Sounds me like the older problem when Delete dialog sometime doesn't show, right? 

http://machydra.brq.redhat.com:8080/job/RedDeer_master_matrix/jdk=sunjdk1.7,label=firebird/646/testReport/junit/org.jboss.reddeer.eclipse.test.ui.views/ResourceNavigatorItemTest/delete_default/?

Error Message

SWT Shell passed to constructor is null. The following shells are available
 class org.eclipse.swt.widgets.Shell with text 'Java - Eclipse Platform'
Stacktrace
org.jboss.reddeer.eclipse.test.ui.views.ResourceNavigatorItemTest.delete default

org.jboss.reddeer.swt.exception.SWTLayerException: SWT Shell passed to constructor is null. The following shells are available
	class org.eclipse.swt.widgets.Shell with text 'Java - Eclipse Platform'

	at org.jboss.reddeer.swt.impl.shell.AbstractShell.<init>(AbstractShell.java:34)
	at org.jboss.reddeer.swt.impl.shell.DefaultShell.<init>(DefaultShell.java:34)
	at org.jboss.reddeer.eclipse.core.resources.ProjectItem.delete(ProjectItem.java:120)
	at org.jboss.reddeer.eclipse.test.jdt.ui.AbstractExplorerItemTest.delete(AbstractExplorerItemTest.java:104)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner$InvokeMethodWithException.evaluate(RequirementsRunner.java:233)
	at org.jboss.reddeer.junit.internal.runner.RunBefores.evaluate(RunBefores.java:79)
	at org.jboss.reddeer.junit.internal.runner.RunAfters.evaluate(RunAfters.java:64)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:129)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.jboss.reddeer.junit.internal.runner.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.CleanUpRequirementStatement.evaluate(CleanUpRequirementStatement.java:25)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:110)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)