### PR TITLE
Increase timeout for eclipse test

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -13,7 +13,10 @@
 	</parent>
 
 	<properties>
-		<surefire.timeout>7200</surefire.timeout>
+		<!-- timeout temporarily set to higher value (originally was 7200)
+		due to slow test execution on mac, see
+		https://github.com/jboss-reddeer/reddeer/issues/1174 -->
+		<surefire.timeout>9600</surefire.timeout>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Timeout for eclipse tests needs to be increased so that it can finish
on mac. We need to find out why it's so slow there. See #1174