### PR TITLE
Possibility to define when requirement extension should be fulfilled

### DIFF
--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/cleanworkspace/CleanWorkspaceRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/cleanworkspace/CleanWorkspaceRequirement.java
@@ -43,12 +43,12 @@ public class CleanWorkspaceRequirement implements Requirement<CleanWorkspace> {
 	 * Marks test class, which requires clean workspace before test cases are executed.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
+    @Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	public @interface CleanWorkspace {
 		
 	}
-	
+		
 	/**
 	 * Always returns true because cleaning workspace should be possible every time.
 	 * 

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/closeeditors/CloseAllEditorsRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/closeeditors/CloseAllEditorsRequirement.java
@@ -20,7 +20,7 @@ import org.jboss.reddeer.requirements.closeeditors.CloseAllEditorsRequirement.Cl
 public class CloseAllEditorsRequirement implements Requirement<CloseAllEditors> {
 
 	@Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
+    @Target({ElementType.METHOD, ElementType.TYPE})
 	public @interface CloseAllEditors {
 		boolean save() default true;
 	}

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/openperspective/OpenPerspectiveRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/openperspective/OpenPerspectiveRequirement.java
@@ -38,7 +38,7 @@ public class OpenPerspectiveRequirement implements Requirement<OpenPerspective> 
 	 * Marks test class, which requires opening of the specified perspective.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target(ElementType.TYPE)
+	@Target({ElementType.TYPE, ElementType.METHOD})
 	@Documented
 	public @interface OpenPerspective {
 		/**

--- a/snippets/src/org/jboss/reddeer/snippet/requirement/OpenConsoleViewRequirement.java
+++ b/snippets/src/org/jboss/reddeer/snippet/requirement/OpenConsoleViewRequirement.java
@@ -18,7 +18,7 @@ public class OpenConsoleViewRequirement implements Requirement<OpenConsoleView> 
     private ConsoleView consoleView = new ConsoleView();
 
     @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
+    @Target({ElementType.METHOD, ElementType.TYPE})
     public @interface OpenConsoleView {
 
     }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/runner/RequirementsRunnerTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/runner/RequirementsRunnerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import org.jboss.reddeer.junit.internal.requirement.Requirements;
 import org.jboss.reddeer.junit.internal.requirement.inject.RequirementsInjector;
 import org.jboss.reddeer.junit.internal.runner.RequirementsRunner;
+import org.jboss.reddeer.requirements.cleanworkspace.CleanWorkspaceRequirement.CleanWorkspace;
 import org.junit.Test;
 
 public class RequirementsRunnerTest {


### PR DESCRIPTION
Ability to define when requirement extension is executed

```java

Transparent requirement usage:
class
test method

@CleanWorkspace
@BeforeClass	// default behavior when used before class statement
public static prepare() {}

@AfterClass - performs fullfill after class (cleanup)
@Before - performs before each
@After - perform after each test (cleanup)

@Test
@CleanWorkspace // dependency performed only for particular test
public vod 

@CleanWorkspace /// this will be performed once at the beginning, same as when used @BeforeClass
 class { ...

```