### PR TITLE
rawagner_foo.bar.myplugin.mars.reddeer.test.AllRedDeerTests failing on Windows

### DIFF
--- a/plugins/org.jboss.reddeer.go/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.go/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.ui;visibility:=reexport,
  org.eclipse.core.runtime;visibility:=reexport,
+ org.eclipse.equinox.event;visibility:=reexport,
  org.junit;bundle-version="4.11.0";visibility:=reexport,
  org.hamcrest.core;bundle-version="1.3.0";visibility:=reexport,
  org.jboss.reddeer.common;bundle-version="[1.0,1.1)";visibility:=reexport,


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_verification_matrix/2177/jdk=sunjdk1.7,label=stable-windows/console

```
spectives
16:30:53.740 INFO [WorkbenchTestable][PreferenceDialog] Open Preferences dialog
16:30:53.740 DEBUG [WorkbenchTestable][AbstractWait] Waiting until shell matching matcher is available....
16:30:53.740 DEBUG [WorkbenchTestable][ShellMatchingMatcherIsAvailable] Looking for shell with title matching matcher
16:30:54.756 DEBUG [WorkbenchTestable][ShellMatchingMatcherIsAvailable] Looking for shell with title matching matcher
16:30:54.756 DEBUG [WorkbenchTestable][AbstractWait] Waiting until shell matching matcher is available. failed, NO exception will be thrown
16:30:54.756 DEBUG [main][Display] UI Call chaining attempt
16:30:54.756 INFO [WorkbenchTestable][WorkbenchPreferenceDialog] Open Preferences by menu
16:30:54.756 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists...
16:30:56.771 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists failed, NO exception will be thrown
16:30:56.771 DEBUG [WorkbenchTestable][AbstractWait] Waiting until shell is focused...
16:30:58.787 DEBUG [WorkbenchTestable][AbstractWait] Waiting until shell is focused failed, NO exception will be thrown
16:30:58.787 ERROR [WorkbenchTestable][RequirementsRunner] Exception in test: foo.bar.myplugin.mars.reddeer.test.BasicTest default
org.jboss.reddeer.core.exception.CoreLayerException: Cannot find menu bar because there's no active shell
	at org.jboss.reddeer.core.lookup.MenuLookup.getActiveShellTopMenuItems(MenuLookup.java:221)
	at org.jboss.reddeer.swt.impl.menu.ShellMenu.<init>(ShellMenu.java:55)
	at org.jboss.reddeer.swt.impl.menu.ShellMenu.<init>(ShellMenu.java:46)
	at org.jboss.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog.openImpl(WorkbenchPreferenceDialog.java:30)
	at org.jboss.reddeer.jface.preference.PreferenceDialog.open(PreferenceDialog.java:52)
	at org.jboss.reddeer.junit.extension.before.test.impl.SetOpenAssociatedPerspectiveExt.setOpenAssociatedPerspective(SetOpenAssociatedPerspectiveExt.java:54)
	at org.jboss.reddeer.junit.extension.before.test.impl.SetOpenAssociatedPerspectiveExt.runBeforeTest(SetOpenAssociatedPerspectiveExt.java:34)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runBeforeTest(RequirementsRunner.java:203)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.withBeforeClasses(RequirementsRunner.java:296)
	at org.junit.runners.ParentRunner.classBlock(ParentRunner.java:192)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:362)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:110)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:53)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
	at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:175)
	at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:123)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:87)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4T
```