### PR TITLE
jpeterka_org.jboss.reddeer.swt.test.EditorBarTest.workbenchToolBarTest is failing

### DIFF
--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/EditorBarTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/EditorBarTest.java
@@ -34,7 +34,7 @@ public class EditorBarTest {
 		// new DefaultShell("Spring Tool Tips").close();
 		new WorkbenchShell();
 		new ShellMenu("File","New","Other...").select();
-		new WaitUntil(new ShellWithTextIsActive("New"));
+		new DefaultShell("New");
 		new DefaultTreeItem("General","Project").select();
 		new PushButton("Next >").click();
 		new WaitUntil(new ShellWithTextIsActive("New Project"));


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_master_matrix/jdk=sunjdk1.7,label=firebird/668/testReport/junit/org.jboss.reddeer.swt.test/EditorBarTest/workbenchToolBarTest_default/?

Error Message

Timeout after: 10 s.: shell with text matching"New" is active
Stacktrace

org.jboss.reddeer.common.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: shell with text matching"New" is active
	at org.jboss.reddeer.common.wait.AbstractWait.timeoutExceeded(AbstractWait.java:159)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:112)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:77)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:53)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:41)
	at org.jboss.reddeer.common.wait.WaitUntil.<init>(WaitUntil.java:25)
	at org.jboss.reddeer.swt.test.EditorBarTest.prepare(EditorBarTest.java:37)