### PR TITLE
rev_org.jboss.reddeer.eclipse.test.ui.browser.BrowserViewTest.testNavigation is failing

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/browser/BrowserViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/browser/BrowserViewTest.java
@@ -15,8 +15,8 @@ import org.junit.runner.RunWith;
 public class BrowserViewTest {
 	protected static BrowserView browserView;
 
-	protected static final String FIRST_PAGE = "http://www.redhat.com/en";
-	protected static final String SECOND_PAGE = "http://www.redhat.com/en/customers";
+	protected static final String FIRST_PAGE = "https://www.google.cz/?q=redhat";
+	protected static final String SECOND_PAGE = "https://www.google.cz/?q=jboss";
 	
 	@Before
 	public void openBrowser(){


### PR DESCRIPTION

http://machydra.brq.redhat.com:8080/job/RedDeer_verification_matrix/jdk=sunjdk1.7,label=stable-windows/2091/testReport/junit/org.jboss.reddeer.eclipse.test.ui.browser/BrowserViewTest/testNavigation_default/?
Error Message

Timeout after: 60 s.: page is loaded to browser
Stacktrace

org.jboss.reddeer.common.exception.WaitTimeoutExpiredException: Timeout after: 60 s.: page is loaded to browser
	at org.jboss.reddeer.common.wait.AbstractWait.timeoutExceeded(AbstractWait.java:159)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:112)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:77)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:53)
	at org.jboss.reddeer.common.wait.WaitUntil.<init>(WaitUntil.java:37)
	at org.jboss.reddeer.swt.impl.browser.AbstractBrowser.forward(AbstractBrowser.java:41)
	at org.jboss.reddeer.eclipse.ui.browser.BrowserView.forward(BrowserView.java:82)
	at org.jboss.reddeer.eclipse.test.ui.browser.BrowserViewTest.testNavigation(BrowserViewTest.java:40)
Standard Output