### PR TITLE
org.jboss.reddeer.workbench.test.editor.TextEditorTest.setCursorPosition failed

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/StyledTextHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/StyledTextHandler.java
@@ -192,4 +192,20 @@ public class StyledTextHandler {
 			}
 		});
 	}
+	
+	
+	/**
+	 * Gets the offset at line
+	 *
+	 * @return offset of text at given line
+	 */
+	public int getOffsetAtLine(final StyledText styledText, final int lineIndex) {
+		return Display.syncExec(new ResultRunnable<Integer>() {
+			public Integer run() {
+				styledText.setFocus();
+				int offsetAtLine = styledText.getOffsetAtLine(lineIndex);
+				return offsetAtLine;
+			}
+		});
+	}
 }

--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/styledtext/AbstractStyledText.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/styledtext/AbstractStyledText.java
@@ -121,5 +121,14 @@ public abstract class AbstractStyledText extends AbstractWidget<org.eclipse.swt.
     @Override	
 	public Point getCursorPosition(){
 		return StyledTextHandler.getInstance().getCursorPosition(swtWidget);
-	}
+	}        
+    
+    /**
+     * Return offset at given line
+     * @param line given line number
+     * @return offset at given line
+     */
+    public int getOffsetAtLine(int line) {
+    	return StyledTextHandler.getInstance().getOffsetAtLine(swtWidget, line); 
+    }
 }

--- a/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/editor/TextEditor.java
+++ b/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/editor/TextEditor.java
@@ -2,12 +2,14 @@ package org.jboss.reddeer.workbench.impl.editor;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.hamcrest.Matcher;
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
+import org.jboss.reddeer.core.handler.StyledTextHandler;
 import org.jboss.reddeer.core.handler.TextEditorHandler;
 import org.jboss.reddeer.core.lookup.EditorPartLookup;
 import org.jboss.reddeer.core.matcher.EditorPartClassMatcher;
@@ -218,8 +220,10 @@ public class TextEditor extends AbstractEditor implements Editor {
 	 */
 	public void setCursorPosition(int line, int column) {
 		log.info("Set cursor position at ["+ line + ", " + column + "]");
-		TextEditorHandler.getInstance().setCursorPosition(getTextEditorPart(),
-				line, column);
+		activate();
+		DefaultStyledText dst = new DefaultStyledText();
+		int lineOffset = dst.getOffsetAtLine(line);
+		setCursorPosition(lineOffset + column);
 	}
 	
 	/**
@@ -231,7 +235,7 @@ public class TextEditor extends AbstractEditor implements Editor {
 		log.info("Set cursor position with offset: " + offset);
 		activate();
 		DefaultStyledText dst = new DefaultStyledText();
-		dst.selectPosition(offset);
+		dst.selectPosition(offset);		
 		new WaitWhile(new JobIsRunning());
 	}
 

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/editor/TextEditorTest.java
@@ -124,7 +124,8 @@ public class TextEditorTest {
 	
 	@Test
 	public void setCursorPosition(){
-		final String firstLine = "package test;";
+		new WorkbenchShell();
+		final String firstLine = "pack";
 		final String firstLineAppend = "testtext";
 		TextEditor textEditor = TextEditorTest.openJavaFile();
 		textEditor.activate();


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_verification_matrix/jdk=sunjdk1.7,label=stable-windows/2194/testReport/junit/org.jboss.reddeer.workbench.test.editor/TextEditorTest/setCursorPosition_default/?

Error Message

Editor doesn't contain expected text at expected position
package test;
public class JavaClass {

 public JavaClass() {
  System.out.println("");
 }

}
Stacktrace

java.lang.AssertionError: Editor doesn't contain expected text at expected position
package test;
public class JavaClass {

	public JavaClass() {
		System.out.println("");
	}

}

	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.jboss.reddeer.workbench.test.editor.TextEditorTest.setCursorPosition(TextEditorTest.java:134)
Standard Output