### PR TITLE
rev_Add support to analyze that screenshot is blank

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/screenshot/ImageTool.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/screenshot/ImageTool.java
@@ -1,0 +1,63 @@
+package org.jboss.reddeer.junit.screenshot;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.jboss.reddeer.common.exception.RedDeerException;
+
+/**
+ * Provides certain functionality to analyze screenshot images
+ * 
+ * @since 1.0
+ * @author Jiri Peterka
+ *
+ */
+public class ImageTool {
+
+	private static ImageTool instance;
+
+	private ImageTool() {
+	}
+
+	public static ImageTool getInstance() {
+		if (instance == null) {
+			instance = new ImageTool();
+		}
+		return instance;
+	}
+
+	/**
+	 * Checks if image is only one color (blank)
+	 * 
+	 * @param filePath absolute path to the image
+	 * @return true if image is one color only (blank) or false if not
+	 */
+	public boolean isImageBlank(String filePath) {
+
+		BufferedImage img;
+		try {
+			img = ImageIO.read(new File(filePath));
+		} catch (IOException e) {
+			throw new RedDeerException("Cannot read image file " + filePath, e);
+		}
+		int width = img.getWidth();
+		int height = img.getHeight();
+		Color first = new Color(img.getRGB(0, 0));
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < height; j++) {
+				int rgb = img.getRGB(i, j);
+				Color c = new Color(rgb);
+				if (!c.equals(first)) {
+					return false;
+				}
+
+			}
+		}
+		return true;
+	}
+
+}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/screenshot/ScreenshotCapturer.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/screenshot/ScreenshotCapturer.java
@@ -105,9 +105,10 @@ public class ScreenshotCapturer {
 	 * Capture screenshot with specified file name. PNG format is supported.
 	 * 
 	 * @param fileName full file name of a screenshot
-	 * @throws CaptureScreenshotException 
+	 * @throws CaptureScreenshotException
+	 * @return absolute path to create screenshot filename 
 	 */
-	public void captureScreenshot(final String screenshotFileName) throws CaptureScreenshotException {
+	public String captureScreenshot(final String screenshotFileName) throws CaptureScreenshotException {
 		String alteredFileName = getAlteredScreenshotFileName(screenshotFileName);
 		final String fileName = createMissingDirectories(alteredFileName);
 		final Display display = Display.getDefault();
@@ -137,6 +138,7 @@ public class ScreenshotCapturer {
 				}
 			}
 		});
+		return fileName;
 	}
 
 	/**


### PR DESCRIPTION
Sometimes screenshot taken during test is blank (white or black usually). This can be caused by several factors (wrong X display, broken GUI session, etc.).  RedDeer should provide API to detect this

```java
ScreenshotCapturer sc = ScreenshotCapturer.getInstance();
String filePath = sc.captureScreenshot("test.png");
ImageAnalyzer ia = new ImageAnalyzer.getInstance();
ia.isImageBlank(filePath);
```