### PR TITLE
Move widget tests to their appropriate package and class

### DIFF
--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/label/DefaultLabelTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/label/DefaultLabelTest.java
@@ -1,4 +1,4 @@
-package org.jboss.reddeer.swt.test;
+package org.jboss.reddeer.swt.test.impl.label;
 
 import static org.junit.Assert.assertTrue;
 
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
-public class LabelTest {
+public class DefaultLabelTest {
 
 	@BeforeClass
 	public static void openExplorer() {

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ContextMenuTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ContextMenuTest.java
@@ -39,7 +39,8 @@ import org.junit.runner.RunWith;
 @RunWith(RedDeerSuite.class)
 @OpenPerspective(JavaPerspective.class)
 public class ContextMenuTest {
-	
+
+	private static int limit = 20;
 	private static String projectName = "ContextMenuTest-test";
 	
 	@BeforeClass
@@ -109,6 +110,37 @@ public class ContextMenuTest {
 		closeTestShell();
 	}
 
+	@Test
+	public void contextMenuTest() {
+
+		ProjectExplorer pe = new ProjectExplorer();
+		pe.open();
+
+		org.jboss.reddeer.swt.api.Menu menu = new ContextMenu("New", "Project...");
+		menu.select();
+		org.jboss.reddeer.swt.api.Shell s = new DefaultShell("New Project");
+		s.close();
+	}
+
+	@Test
+	public void hundertscontextMenuTest() {
+		for (int i = 0; i < limit; i++) {
+			contextMenuTest();
+		}
+	}
+
+	@Test
+	public void contextMenuItemTextTest() {
+		// make sure shell is focused
+		new DefaultShell();
+
+		ProjectExplorer pe = new ProjectExplorer();
+		pe.open();
+
+		org.jboss.reddeer.swt.api.Menu menu = new ContextMenu("New", "Project...");
+		assertTrue("Menuitem text not expected to be empty", !menu.getText().equals(""));
+	}
+	
 	private void closeTestShell() {
 		new DefaultShell("myShell").close();
 	}
@@ -151,5 +183,4 @@ public class ContextMenuTest {
 			}
 		});
 	}
-	
 }

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ShellMenuTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/menu/ShellMenuTest.java
@@ -1,43 +1,35 @@
-package org.jboss.reddeer.swt.test;
+package org.jboss.reddeer.swt.test.impl.menu;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.jboss.reddeer.common.logging.Logger;
-import org.jboss.reddeer.junit.runner.RedDeerSuite;
-import org.jboss.reddeer.swt.api.Menu;
-import org.jboss.reddeer.swt.api.Shell;
-import org.jboss.reddeer.swt.exception.SWTLayerException;
-import org.jboss.reddeer.swt.impl.menu.ContextMenu;
-import org.jboss.reddeer.swt.impl.menu.ShellMenu;
-import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.common.matcher.RegexMatcher;
 import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.core.matcher.WithMnemonicTextMatcher;
 import org.jboss.reddeer.core.matcher.WithTextMatcher;
 import org.jboss.reddeer.core.matcher.WithTextMatchers;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.api.Menu;
+import org.jboss.reddeer.swt.api.Shell;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/**
- * 
- * @author Jiri Peterka
- *
- */
 @RunWith(RedDeerSuite.class)
-public class MenuTest {
-
+public class ShellMenuTest {
 	protected final Logger log = Logger.getLogger(this.getClass());
 	private ProjectExplorer explorer = new ProjectExplorer();
-	private static int limit = 20;
 
 	@Before
 	public void setUp() {
 		explorer.open();
 	}
-	
+
 	@Test
 	public void preferencesMenuTest() {
 		log.info("Preferences menu test");
@@ -47,14 +39,13 @@ public class MenuTest {
 		Shell s = new DefaultShell("Preferences");
 		s.close();
 	}
-	
+
 	@Test
 	public void aboutMenuTest() {
 		log.info("About menu test");
 		new DefaultShell();
 		@SuppressWarnings("unchecked")
-		Menu m = new ShellMenu(new WithMnemonicTextMatcher("Help"),
-			new WithTextMatcher(new RegexMatcher("About.*")));
+		Menu m = new ShellMenu(new WithMnemonicTextMatcher("Help"), new WithTextMatcher(new RegexMatcher("About.*")));
 		m.select();
 		Shell s = new DefaultShell();
 		s.close();
@@ -74,10 +65,7 @@ public class MenuTest {
 
 		log.info("regex menu test");
 		try {
-			RegexMatcher[] regexMatchers = { 
-					new RegexMatcher("Win.*"),
-					new RegexMatcher("Pref.*") 
-			};
+			RegexMatcher[] regexMatchers = { new RegexMatcher("Win.*"), new RegexMatcher("Pref.*") };
 			WithTextMatchers m = new WithTextMatchers(regexMatchers);
 			new ShellMenu(m.getMatchers());
 		} catch (SWTLayerException e) {
@@ -90,10 +78,7 @@ public class MenuTest {
 	public void unavailableMenuTest() {
 		log.info("unavailable regex menu test");
 		try {
-			RegexMatcher[] regexMatchers = { 
-					new RegexMatcher("Win.*"),
-					new RegexMatcher("Prefz.*") 
-			};
+			RegexMatcher[] regexMatchers = { new RegexMatcher("Win.*"), new RegexMatcher("Prefz.*") };
 			WithTextMatchers m = new WithTextMatchers(regexMatchers);
 			new ShellMenu(m.getMatchers());
 			fail("exception should be thrown");
@@ -101,59 +86,27 @@ public class MenuTest {
 
 		}
 	}
-	
-	@Test 
-	public void contextMenuTest() {
-		
-		ProjectExplorer pe = new ProjectExplorer();
-		pe.open();
-			
-		Menu menu = new ContextMenu("New","Project...");
-		menu.select();
-		Shell s = new DefaultShell("New Project");
-		s.close();
-	}
-	
-	@Test 
-	public void hundertscontextMenuTest() {
-		for (int i = 0; i < limit; i++) {
-			contextMenuTest();
-		}
-	}	
-	
-	@Test 
-	public void contextMenuItemTextTest() {
-		//make sure shell is focused
-		new DefaultShell();
-		
-		ProjectExplorer pe = new ProjectExplorer();
-		pe.open();
-		
-		Menu menu = new ContextMenu("New","Project...");
-		assertTrue("Menuitem text not expected to be empty", !menu.getText().equals(""));
-	}
-	
-	
-	@Test 
+
+	@Test
 	public void shellMenuItemTextTest() {
 		new DefaultShell();
 		Menu menu = new ShellMenu("Window", "Preferences");
 		assertTrue("Menuitem text not expected to be empty", !menu.getText().equals(""));
 	}
-	
+
 	@Test
 	public void menuWithMnemonicTest() {
 		log.info("menu with mnemonic test");
 		new DefaultShell();
-		Menu m = new ShellMenu("File", "New" , "Other...");
+		Menu m = new ShellMenu("File", "New", "Other...");
 		m.select();
 		Shell s = new DefaultShell("New");
 		s.close();
 	}
-	
+
 	private class ProjectExplorer extends WorkbenchView {
 		public ProjectExplorer() {
-			super("General","Project Explorer");
+			super("General", "Project Explorer");
 		}
 	}
 }

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/DefaultTextTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/DefaultTextTest.java
@@ -1,4 +1,4 @@
-package org.jboss.reddeer.swt.test;
+package org.jboss.reddeer.swt.test.impl.text;
 
 
 import static org.junit.Assert.assertTrue;
@@ -9,14 +9,13 @@ import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
 import org.jboss.reddeer.swt.impl.text.DefaultText;
-import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
-public class TextTest {
+public class DefaultTextTest {
 
 	@BeforeClass
 	public static void openExplorer() {
@@ -43,15 +42,5 @@ public class TextTest {
 		t.setText("myvalue");
 		assertTrue(t.getText().equals("myvalue"));
 		new PushButton("Cancel").click();
-	}
-
-	@Test
-	public void labeledTextTest() {
-		assertTrue(new LabeledText("Name:").getText().equals("Original text"));
-		Text text = new LabeledText("Name:");
-		assertTrue(text.getText().equals("Original text"));
-		text.setText("New text");
-		assertTrue(text.getText().equals("New text"));
-		text.setText("Original text");
 	}
 }

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/StyledTextTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/StyledTextTest.java
@@ -1,4 +1,4 @@
-package org.jboss.reddeer.swt.test;
+package org.jboss.reddeer.swt.test.impl.text;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/shell/DefaultShellTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/shell/DefaultShellTest.java
@@ -1,4 +1,4 @@
-package org.jboss.reddeer.swt.test;
+package org.jboss.reddeer.swt.test.shell;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -6,37 +6,31 @@ import static org.junit.Assert.fail;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Label;
-import org.jboss.reddeer.junit.runner.RedDeerSuite;
-import org.jboss.reddeer.swt.api.Shell;
-import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.core.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.core.handler.ShellHandler;
+import org.jboss.reddeer.core.util.Display;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.api.Shell;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.impl.button.PushButton;
 import org.jboss.reddeer.swt.impl.label.DefaultLabel;
 import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
-import org.jboss.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.jboss.reddeer.core.util.Display;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(RedDeerSuite.class)
-public class ShellTest {
+public class DefaultShellTest {
 	
+
 	private Shell shell1,shell2;
-	
-	@Test
-	public void workbenchShellTest() {
-		Shell shell = new WorkbenchShell();
-		assertFalse(shell.getText().equals(""));
-	}
 
 	@Test
-	public void DefaultShellTest() {
+	public void defaultShellTest() {
 		Shell shell = new DefaultShell();
 		assertFalse(shell.getText().equals(""));
 	}
@@ -57,16 +51,6 @@ public class ShellTest {
 
 		Shell dummyShell = new DefaultShell("Dummy shell");
 		dummyShell.close();
-	}
-	
-	@Test
-	public void maximizeWorkbenshShellTest() {
-		WorkbenchShell workbenchShell = new WorkbenchShell();
-		assertFalse(workbenchShell.isMaximized());
-		workbenchShell.maximize();
-		assertTrue(workbenchShell.isMaximized());
-		workbenchShell.restore();
-		assertFalse(workbenchShell.isMaximized());
 	}
 
 	@Test

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/shell/WorkbenchShellTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/shell/WorkbenchShellTest.java
@@ -1,0 +1,30 @@
+package org.jboss.reddeer.swt.test.shell;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.api.Shell;
+import org.jboss.reddeer.workbench.impl.shell.WorkbenchShell;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(RedDeerSuite.class)
+public class WorkbenchShellTest {
+	
+	@Test
+	public void workbenchShellTest() {
+		Shell shell = new WorkbenchShell();
+		assertFalse(shell.getText().equals(""));
+	}
+	
+	@Test
+	public void maximizeWorkbenshShellTest() {
+		WorkbenchShell workbenchShell = new WorkbenchShell();
+		assertFalse(workbenchShell.isMaximized());
+		workbenchShell.maximize();
+		assertTrue(workbenchShell.isMaximized());
+		workbenchShell.restore();
+		assertFalse(workbenchShell.isMaximized());
+	}
+}

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolbar/DefaultToolBarTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolbar/DefaultToolBarTest.java
@@ -1,12 +1,14 @@
-package org.jboss.reddeer.swt.test;
+package org.jboss.reddeer.swt.test.toolbar;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.hamcrest.core.Is;
 import org.hamcrest.core.IsNot;
+import org.jboss.reddeer.common.matcher.RegexMatcher;
+import org.jboss.reddeer.core.matcher.WithTextMatchers;
+import org.jboss.reddeer.core.matcher.WithTooltipTextMatcher;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.api.ToolBar;
@@ -17,37 +19,28 @@ import org.jboss.reddeer.swt.impl.clabel.DefaultCLabel;
 import org.jboss.reddeer.swt.impl.label.DefaultLabel;
 import org.jboss.reddeer.swt.impl.menu.ShellMenu;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;
-import org.jboss.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.jboss.reddeer.swt.impl.toolbar.DefaultToolBar;
 import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
-import org.jboss.reddeer.swt.impl.toolbar.ViewToolBar;
 import org.jboss.reddeer.swt.impl.tree.DefaultTree;
 import org.jboss.reddeer.swt.impl.tree.DefaultTreeItem;
-import org.jboss.reddeer.common.matcher.RegexMatcher;
-import org.jboss.reddeer.core.matcher.WithTextMatchers;
-import org.jboss.reddeer.core.matcher.WithTooltipTextMatcher;
-import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
+import org.jboss.reddeer.workbench.impl.shell.WorkbenchShell;
 import org.jboss.tools.reddeer.swt.test.model.TestModel;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/**
- * Tests for various toolbar implementations
- * @author Jiri Peterka
- *
- */
 @RunWith(RedDeerSuite.class)
-public class ToolBarTest {
+public class DefaultToolBarTest {
 
-	@Before
-	public void prepare() {
-		new WorkbenchView("RedDeer SWT").open();
+	@Test
+	public void testDefaultToolBar() {
+		openPreferences();
+		final ToolBar t = new DefaultToolBar();
+		assertNotNull(t);
+		closePreferences();	
 	}
 	
 	@Test 
-	public void workbenchToolBarTest() {
-		
+	public void workbenchToolBarTest() {		
 		ToolItem i = new DefaultToolItem(new WorkbenchShell(), "RedDeer SWT WorkbenchToolItem");
 		i.click();
 		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());
@@ -61,43 +54,7 @@ public class ToolBarTest {
 		i.click();
 		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());
 	}
-
-	@Test
-	public void testToolBar() {
-		new WorkbenchShell();
-		ToolBar t = new ViewToolBar();
-		assertNotNull(t);
-	}
-
-	@Test
-	public void testToolItemInViewToolBarFound() {
-		ToolItem i = new DefaultToolItem("RedDeer SWT ViewToolItem");
-		assertEquals("RedDeer SWT ViewToolItem", i.getToolTipText());
-	}
-
-	@Test
-	public void testToolItemInViewToolBarClicked() {
-		ToolItem i = new DefaultToolItem("RedDeer SWT ViewToolItem");
-		i.click();		
-		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());		
-	}
-
-	@Test
-	public void testToolItemInViewToolBarRegexClicked() {
-		WithTooltipTextMatcher rm = new WithTooltipTextMatcher(
-				new RegexMatcher("RedDeer SWT View.*"));
-		ToolItem i = new DefaultToolItem(rm);
-		i.click();
-		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());		
-	}
 	
-	@Test
-	public void testShellToolBar() {
-		openPreferences();
-		final ToolBar t = new DefaultToolBar();
-		assertNotNull(t);
-		closePreferences();	
-	}
 	
 	@Test
 	public void testToolItemInShellToolBarFound() {

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolbar/ViewToolBarTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/toolbar/ViewToolBarTest.java
@@ -1,0 +1,57 @@
+package org.jboss.reddeer.swt.test.toolbar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.reddeer.common.matcher.RegexMatcher;
+import org.jboss.reddeer.core.matcher.WithTooltipTextMatcher;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.api.ToolBar;
+import org.jboss.reddeer.swt.api.ToolItem;
+import org.jboss.reddeer.swt.impl.toolbar.DefaultToolItem;
+import org.jboss.reddeer.swt.impl.toolbar.ViewToolBar;
+import org.jboss.reddeer.workbench.impl.shell.WorkbenchShell;
+import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
+import org.jboss.tools.reddeer.swt.test.model.TestModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(RedDeerSuite.class)
+public class ViewToolBarTest {
+
+	@Before
+	public void prepare() {
+		new WorkbenchView("RedDeer SWT").open();
+	}
+	
+	@Test
+	public void testViewToolBar() {
+		new WorkbenchShell();
+		ToolBar t = new ViewToolBar();
+		assertNotNull(t);
+	}
+	
+	@Test
+	public void testToolItemInViewToolBarFound() {
+		ToolItem i = new DefaultToolItem("RedDeer SWT ViewToolItem");
+		assertEquals("RedDeer SWT ViewToolItem", i.getToolTipText());
+	}
+
+	@Test
+	public void testToolItemInViewToolBarClicked() {
+		ToolItem i = new DefaultToolItem("RedDeer SWT ViewToolItem");
+		i.click();		
+		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());		
+	}
+
+	@Test
+	public void testToolItemInViewToolBarRegexClicked() {
+		WithTooltipTextMatcher rm = new WithTooltipTextMatcher(
+				new RegexMatcher("RedDeer SWT View.*"));
+		ToolItem i = new DefaultToolItem(rm);
+		i.click();
+		assertTrue("ToolItem should be clicked", TestModel.getClickedAndReset());		
+	}	
+}


### PR DESCRIPTION
Splits some classes that grouped different widget implementation tests into separate classes and moves the into the appropriate packages. Fills in the missing test classes from #794.