### PR TITLE
jpeterka_Screenshot not created when screenshot directory does not exist

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/screenshot/ScreenshotCapturer.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/screenshot/ScreenshotCapturer.java
@@ -73,8 +73,8 @@ public class ScreenshotCapturer {
 			
 			captureScreenshot(path + name + ".png");
 		} else {
-			throw new CaptureScreenshotException("Screenshot could not be created, "
-					+ "because required folders where to store screenshot has not been created");
+			logger.warn("Screenshot has not been captured on failure, because RedDeer property whether screenshot "
+					+ "should be captured or not is set to false.");
 		}
 
 	}


### PR DESCRIPTION
11:55:17.333 INFO [WorkbenchTestable][Requirements] Fulfilling requirement of class org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement
11:55:17.335 ERROR [WorkbenchTestable][Requirements] Capturing screenshot failed because of following error: Screenshot could not be created, because required folders where to store screenshot has not been created
11:55:17.335 ERROR [WorkbenchTestable][Requirements] Error was caused by: 
null
11:55:17.335 INFO [WorkbenchTestable][ShellHandler] Closing all shells...
11:55:17.341 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists...
11:55:17.342 DEBUG [WorkbenchTestable][AbstractWait] Waiting until active shell exists finished successfully

Check log of job RedDeer_verification_matrix/2236/jdk=sunjdk1.7,label=stable-linux/consoleText

