### PR TITLE
rev_org.jboss.reddeer.eclipse.test.ui.views.properties.TabbedPropertiesTest.selectTabTest failed

### DIFF
--- a/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/shell/AbstractShell.java
+++ b/plugins/org.jboss.reddeer.swt/src/org/jboss/reddeer/swt/impl/shell/AbstractShell.java
@@ -5,12 +5,12 @@ import org.eclipse.swt.widgets.Control;
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.common.wait.WaitWhile;
-import org.jboss.reddeer.core.condition.ShellWithTextIsActive;
 import org.jboss.reddeer.core.condition.ShellWithTextIsAvailable;
 import org.jboss.reddeer.core.handler.ShellHandler;
 import org.jboss.reddeer.core.handler.WidgetHandler;
 import org.jboss.reddeer.core.util.DiagnosticTool;
 import org.jboss.reddeer.swt.api.Shell;
+import org.jboss.reddeer.swt.condition.ShellIsActive;
 import org.jboss.reddeer.swt.exception.SWTLayerException;
 import org.jboss.reddeer.swt.impl.button.CancelButton;
 
@@ -50,7 +50,7 @@ public abstract class AbstractShell implements Shell {
 	public void setFocus() {
 		log.debug("Set focus to Shell " + getText());
 		WidgetHandler.getInstance().setFocus(swtShell);
-		new WaitUntil(new ShellWithTextIsActive(getText()));
+		new WaitUntil(new ShellIsActive(this));
 	}
 	
 	@Override


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_verification_matrix/jdk=sunjdk1.7,label=stable-linux/2220/testReport/junit/org.jboss.reddeer.eclipse.test.ui.views.properties/TabbedPropertiesTest/selectTabTest_default/?

org.jboss.reddeer.eclipse.test.ui.views.properties.TabbedPropertiesTest.selectTabTest default

Failing for the past 1 build (Since Unstable#2220 )
Took 10 sec.
edit description
Error Message

Timeout after: 10 s.: shell with text matching"Java - Eclipse Platform" is active
Stacktrace

org.jboss.reddeer.common.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: shell with text matching"Java - Eclipse Platform" is active
	at org.jboss.reddeer.common.wait.AbstractWait.timeoutExceeded(AbstractWait.java:159)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:112)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:77)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:53)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:41)
	at org.jboss.reddeer.common.wait.WaitUntil.<init>(WaitUntil.java:25)
	at org.jboss.reddeer.swt.impl.shell.AbstractShell.setFocus(AbstractShell.java:53)
	at org.jboss.reddeer.workbench.impl.shell.WorkbenchShell.<init>(WorkbenchShell.java:24)
	at org.jboss.reddeer.workbench.impl.view.AbstractView.getViewCTabItem(AbstractView.java:124)
	at org.jboss.reddeer.workbench.impl.view.AbstractView.<init>(AbstractView.java:74)
	at org.jboss.reddeer.workbench.impl.view.AbstractView.<init>(AbstractView.java:61)
	at org.jboss.reddeer.workbench.impl.view.WorkbenchView.<init>(WorkbenchView.java:21)
	at org.jboss.reddeer.eclipse.jdt.ui.AbstractExplorer.<init>(AbstractExplorer.java:35)
	at org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer.<init>(ProjectExplorer.java:15)
	at org.jboss.reddeer.eclipse.test.ui.views.properties.TabbedPropertiesTest.openXsdFile(TabbedPropertiesTest.java:67)