### PR TITLE
rev_RedDeer mvn archetype append "reddeer.test" right after provided module/project name

### DIFF
--- a/archetype/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/archetype/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -14,9 +14,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ${artifactId} Reddeer Test
-Bundle-SymbolicName: ${artifactId}.reddeer.test
+Bundle-SymbolicName: ${artifactId}
 Bundle-Version: ${futureVersion}.qualifier
-Bundle-Activator: ${package}.reddeer.test.Activator
+Bundle-Activator: ${package}.Activator
 Bundle-RequiredExecutionEnvironment: J2SE-1.5,
  JavaSE-1.6
 Require-Bundle: org.jboss.reddeer.go${rd_version}

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
-  <artifactId>${artifactId}.reddeer.test</artifactId>
+  <artifactId>${artifactId}</artifactId>
   <version>${version}</version>
   <name>${artifactId} :: test</name>
   <description>${artifactId} test plugin</description>
@@ -95,8 +95,8 @@
           <configuration>
             <useUIHarness>true</useUIHarness>
             <useUIThread>false</useUIThread>
-            <testSuite>${artifactId}.reddeer.test</testSuite>
-            <testClass>${package}.reddeer.test.AllRedDeerTests</testClass>
+            <testSuite>${artifactId}</testSuite>
+            <testClass>${package}.AllRedDeerTests</testClass>
             <!-- THE FOLLOWING LINE MUST NOT BE BROKEN BY AUTOFORMATTING -->
             <argLine>${symbol_dollar}{tycho.test.jvmArgs} ${symbol_dollar}{platformSystemProperties}</argLine>
 	    	<includes>

--- a/archetype/src/main/resources/archetype-resources/src/Activator.java
+++ b/archetype/src/main/resources/archetype-resources/src/Activator.java
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-package ${package}.reddeer.test;
+package ${package};
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
@@ -12,7 +12,7 @@ import org.osgi.framework.BundleContext;
 public class Activator extends AbstractUIPlugin {
 
         // The plug-in ID
-        public static final String PLUGIN_ID = "${artifactId}.reddeer.test";
+        public static final String PLUGIN_ID = "${artifactId}";
 
         // The shared instance
         private static Activator plugin;

--- a/archetype/src/main/resources/archetype-resources/src/AllRedDeerTests.java
+++ b/archetype/src/main/resources/archetype-resources/src/AllRedDeerTests.java
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-package ${package}.reddeer.test;
+package ${package};
 
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.junit.runner.RunWith;

--- a/archetype/src/main/resources/archetype-resources/src/BasicTest.java
+++ b/archetype/src/main/resources/archetype-resources/src/BasicTest.java
@@ -1,7 +1,7 @@
 #set( $symbol_pound = '#' )
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
-package ${package}.reddeer.test;
+package ${package};
 
 import static org.junit.Assert.assertTrue;
 import org.jboss.reddeer.swt.impl.shell.DefaultShell;


### PR DESCRIPTION
E.g. I want to create a module "org.jboss.reddeer.custom" but I get as a result "org.jboss.reddeer.custom.reddeer.test"