### PR TITLE
Improve finding labeled widgets

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
@@ -2,6 +2,7 @@ package org.jboss.reddeer.core.handler;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
@@ -186,7 +187,7 @@ public class WidgetHandler {
 
 			@Override
 			public String run() {
-				Widget parent = ((Control) w).getParent();
+				Control parent = ((Control) w).getParent();
 				java.util.List<Widget> children = WidgetResolver.getInstance()
 						.getChildren(parent);
 				// check whether a label is defined using form data layout
@@ -205,22 +206,24 @@ public class WidgetHandler {
 						}
 					}
 				}
-				for (int i = 1; i < children.size(); i++) {
-					if (children.get(i) != null && children.get(i).equals(w)) {
-						for (int y = 1; i - y >= 0; y++) {
-							if (children.get(i - y) instanceof Label) {
-								if (((Label) children.get(i - y)).getImage() == null) {
-									return ((Label) children.get(i - y))
-											.getText();
-								}
-							} else if (children.get(i - y) instanceof CLabel) {
-								if (((CLabel) children.get(i - y)).getImage() == null) {
-									return ((CLabel) children.get(i - y))
-											.getText();
-								}
-							} else {
-								return null;
-							}
+				List<Control> allWidgets = WidgetLookup.getInstance().findAllParentWidgets();
+				int widgetIndex = allWidgets.indexOf(w);
+				if (widgetIndex < 0) {
+					throw new CoreLayerException("Wrong implementation for finding labels!");
+				}
+				ListIterator<? extends Widget> listIterator = allWidgets.listIterator(widgetIndex);
+				while (listIterator.hasPrevious()) {
+					Widget previousWidget = listIterator.previous();
+					if (previousWidget instanceof Label) {
+						Label label = (Label) previousWidget;
+						if (label.getImage() == null) {
+							return label.getText();
+						}
+					}
+					if (previousWidget instanceof CLabel) {
+						CLabel cLabel = (CLabel) previousWidget;
+						if (cLabel.getImage() == null) {
+							return cLabel.getText();
 						}
 					}
 				}

--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/WidgetLookup.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/WidgetLookup.java
@@ -10,6 +10,8 @@ import org.eclipse.swt.widgets.Widget;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchSite;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.jboss.reddeer.common.exception.WaitTimeoutExpiredException;
 import org.jboss.reddeer.common.logging.Logger;
@@ -358,5 +360,23 @@ public class WidgetLookup {
 		}
 		return sb.toString();
 	}
+
+	public List<Control> findAllParentWidgets() {
+		List<Control> allWidgets = findControls(findParent(), new BaseMatcher<Control>() {
+
+			@Override
+			public boolean matches(Object obj) {
+				return true;
+			}
+
+			@Override
+			public void describeTo(Description desc) {
+				
+			}
+			
+		}, true);
+		return allWidgets;
+	}
+
 }
 

--- a/tests/org.jboss.reddeer.generator.test/src/org/jboss/reddeer/generator/test/ComboCodeGeneratorTest.java
+++ b/tests/org.jboss.reddeer.generator.test/src/org/jboss/reddeer/generator/test/ComboCodeGeneratorTest.java
@@ -1,14 +1,18 @@
 package org.jboss.reddeer.generator.test;
 
+import static org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils.assertConstructorCode;
+import static org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils.closeTestingShell;
+import static org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils.createTestedControlWithShell;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.jboss.reddeer.generator.CodeGenerator;
 import org.jboss.reddeer.generator.ComboCodeGenerator;
+import org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
-import org.jboss.reddeer.core.util.Display;
-import org.junit.Assert;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -22,37 +26,42 @@ public class ComboCodeGeneratorTest {
 
 	private static CodeGenerator codeGenerator = new ComboCodeGenerator();
 
+	@After
+	public void closeShell() {
+		closeTestingShell();
+	}
+
 	@Test
 	public void getConstructorTextWithLabelTest() {
-		Display.syncExec(new Runnable() {
+		Combo combo = createTestedControlWithShell(new CodeGeneratorTestUtils.TestingShell<Combo>() {
 
 			@Override
-			public void run() {
-				Shell shell = new Shell();
+			public Combo createControls(Shell shell) {
 				Label label = new Label(shell, SWT.LEFT);
 				label.setText("Test");
 				label.setSize(100, 30);
 				Combo combo = new Combo(shell, SWT.LEFT);
 				combo.setSize(200, 30);
-				Assert.assertEquals("new LabeledCombo(\"Test\")", codeGenerator.getConstructor(combo));
+				return combo;
 			}
 		});
 
+		assertConstructorCode("new LabeledCombo(\"Test\")", codeGenerator, combo);
 	}
 
 	@Test
 	public void getConstructorTextWithoutLabelTest() {
-		Display.syncExec(new Runnable() {
+		Combo combo = createTestedControlWithShell(new CodeGeneratorTestUtils.TestingShell<Combo>() {
 
 			@Override
-			public void run() {
-				Shell shell = new Shell();
+			public Combo createControls(Shell shell) {
 				Combo combo = new Combo(shell, SWT.LEFT);
 				combo.setSize(200, 30);
-				Assert.assertEquals("new DefaultCombo(0)", codeGenerator.getConstructor(combo));
+				return combo;
 			}
 		});
 
+		assertConstructorCode("new DefaultCombo(0)", codeGenerator, combo);
 	}
 
 }

--- a/tests/org.jboss.reddeer.generator.test/src/org/jboss/reddeer/generator/test/TextCodeGeneratorTest.java
+++ b/tests/org.jboss.reddeer.generator.test/src/org/jboss/reddeer/generator/test/TextCodeGeneratorTest.java
@@ -1,14 +1,18 @@
 package org.jboss.reddeer.generator.test;
 
+import static org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils.assertConstructorCode;
+import static org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils.closeTestingShell;
+import static org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils.createTestedControlWithShell;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.jboss.reddeer.generator.CodeGenerator;
 import org.jboss.reddeer.generator.TextCodeGenerator;
+import org.jboss.reddeer.generator.test.utils.CodeGeneratorTestUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
-import org.jboss.reddeer.core.util.Display;
-import org.junit.Assert;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -22,36 +26,43 @@ public class TextCodeGeneratorTest {
 
 	private static CodeGenerator codeGenerator = new TextCodeGenerator();
 
+	@After
+	public void closeShell() {
+		closeTestingShell();
+	}
+
 	@Test
 	public void getConstructorTextWithLabelTest() {
-		Display.syncExec(new Runnable() {
+		Text text = createTestedControlWithShell(new CodeGeneratorTestUtils.TestingShell<Text>() {
 
 			@Override
-			public void run() {
-				Shell shell = new Shell();
+			public Text createControls(Shell shell) {
 				Label label = new Label(shell, SWT.LEFT);
 				label.setText("Test");
 				label.setSize(100, 30);
 				Text text = new Text(shell, SWT.LEFT);
 				text.setSize(200, 30);
-				Assert.assertEquals("new LabeledText(\"Test\")", codeGenerator.getConstructor(text));
+				return text;
 			}
 		});
+
+		assertConstructorCode("new LabeledText(\"Test\")", codeGenerator, text);
 
 	}
 
 	@Test
 	public void getConstructorTextWithoutLabelTest() {
-		Display.syncExec(new Runnable() {
+		Text text = createTestedControlWithShell(new CodeGeneratorTestUtils.TestingShell<Text>() {
 
 			@Override
-			public void run() {
-				Shell shell = new Shell();
+			public Text createControls(Shell shell) {
 				Text text = new Text(shell, SWT.LEFT);
 				text.setSize(200, 30);
-				Assert.assertEquals("new DefaultText(0)", codeGenerator.getConstructor(text));
+				return text;
 			}
 		});
+
+		assertConstructorCode("new DefaultText(0)", codeGenerator, text);
 
 	}
 

--- a/tests/org.jboss.reddeer.generator.test/src/org/jboss/reddeer/generator/test/utils/CodeGeneratorTestUtils.java
+++ b/tests/org.jboss.reddeer.generator.test/src/org/jboss/reddeer/generator/test/utils/CodeGeneratorTestUtils.java
@@ -1,0 +1,50 @@
+package org.jboss.reddeer.generator.test.utils;
+
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.jboss.reddeer.core.handler.ShellHandler;
+import org.jboss.reddeer.core.util.Display;
+import org.jboss.reddeer.core.util.ResultRunnable;
+import org.jboss.reddeer.generator.CodeGenerator;
+import org.junit.Assert;
+
+public class CodeGeneratorTestUtils {
+
+	private static Shell shell;
+
+	public static void assertConstructorCode(String expectedCode, final CodeGenerator generator, final Control control) {
+		String actualCode = Display.syncExec(new ResultRunnable<String>() {
+
+			@Override
+			public String run() {
+				return generator.getConstructor(control);
+			}
+
+		});
+		Assert.assertEquals(expectedCode, actualCode);
+	}
+
+	public static void closeTestingShell() {
+		ShellHandler.getInstance().closeShell(shell);
+	}
+
+	public static <T> T createTestedControlWithShell(final TestingShell<T> testingShell) {
+		return Display.syncExec(new ResultRunnable<T>() {
+			@Override
+			public T run() {
+				shell = new Shell();
+				shell.setText("Testing Shell");
+				T control = testingShell.createControls(shell);
+				shell.open();
+				shell.setFocus();
+				shell.layout();
+				return control;
+			}
+		});
+	}
+
+	public interface TestingShell<T> {
+
+		T createControls(Shell shell);
+	}
+}

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
@@ -3,6 +3,7 @@ package org.jboss.reddeer.swt.test.impl.text;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
@@ -77,7 +78,7 @@ public class LabeledTextTest extends SWTLayerTestCase {
 		swtText3.setMessage("message");
 
 		LabelTestUtils.createCLabel(shell, "Test clabel");
-		TextTestUtils.createText(shell, "Test text4");
+		TextTestUtils.createText(shell, "Test ctext");
 		
 		Composite formContainer = LayoutTestUtils.createFlatFormComposite(shell);
 
@@ -94,6 +95,10 @@ public class LabeledTextTest extends SWTLayerTestCase {
 		CLabel label2 = LabelTestUtils.createCLabel(formContainer, "");
 		label2.setText("FormCLabel");
 		label2.setLayoutData(LayoutTestUtils.labelLayoutData(text2));
+		
+		LabelTestUtils.createLabel(shell, "Test label4");
+		Composite composite = new Composite(shell, SWT.LEFT);
+		Text text4 = TextTestUtils.createText(composite, "Test text4");
 	}
 	
 	@Test
@@ -129,7 +134,13 @@ public class LabeledTextTest extends SWTLayerTestCase {
 	@Test
 	public void findLabeledTextWithCLabel(){
 		new DefaultShell(SHELL_TITLE);
-		assertTrue(new LabeledText("Test clabel").getText().equals("Test text4"));
+		assertTrue(new LabeledText("Test clabel").getText().equals("Test ctext"));
+	}
+	
+	@Test
+	public void findLabeledTextWithOutsideLabel(){
+		new DefaultShell(SHELL_TITLE);
+		assertTrue(new LabeledText("Test label4").getText().equals("Test text4"));
 	}
 
 	@Test


### PR DESCRIPTION
Currently, the implementation of WithLabelMatcher doesn't find some text fields if the widgets don't create a proper tree. SWTBot solves also such situations.