### PR TITLE
Method PreferenceDialog.select() takes too long

### DIFF
--- a/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/jface/preference/PreferenceDialog.java
+++ b/plugins/org.jboss.reddeer.jface/src/org/jboss/reddeer/jface/preference/PreferenceDialog.java
@@ -80,7 +80,7 @@ public abstract class PreferenceDialog {
 		TreeItem t = new DefaultTreeItem(path);
 		t.select();
 		
-		new WaitUntil(new CLabelWithTextIsAvailable(path[path.length-1]), TimePeriod.NORMAL, false);
+		new WaitUntil(new CLabelWithTextIsAvailable(path[path.length-1]), TimePeriod.SHORT, false);
 	}
 	
 	/**


### PR DESCRIPTION
The wait condition takes 10s so pages that do not have the same path as the page name wait very long to be selected. 
```
public void select(String... path) {
		if (path == null) {
			throw new IllegalArgumentException("path can't be null");
		}
		if (path.length == 0) {
			throw new IllegalArgumentException("path can't be empty");
		}
		TreeItem t = new DefaultTreeItem(path);
		t.select();
		
		new WaitUntil(new CLabelWithTextIsAvailable(path[path.length-1]), TimePeriod.NORMAL, false);
	}
```