### PR TITLE
Create a requirement for turning off auto building

### DIFF
--- a/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/preferences/PreferencesUtil.java
+++ b/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/preferences/PreferencesUtil.java
@@ -1,0 +1,42 @@
+package org.jboss.reddeer.direct.preferences;
+
+import org.jboss.reddeer.common.logging.Logger;
+
+/**
+ * This is a util class for setting common preferences.
+ * 
+ * @author Andrej Podhradsky
+ *
+ */
+public class PreferencesUtil {
+
+	public static final String AUTO_BUILDING_PLUGIN = "org.eclipse.core.resources";
+	public static final String AUTO_BUILDING_KEY = "description.autobuilding";
+
+	private static final Logger log = Logger.getLogger(PreferencesUtil.class);
+
+	/**
+	 * Decides whether the auto building is on/off.
+	 * 
+	 * @return true if the auto building is on, false otherwise
+	 */
+	public static boolean isAutoBuildingOn() {
+		return "true".equalsIgnoreCase(Preferences.get(AUTO_BUILDING_PLUGIN, AUTO_BUILDING_KEY));
+	}
+
+	/**
+	 * Sets the auto building on.
+	 */
+	public static void setAutoBuildingOn() {
+		log.info("Setting the auto building ON.");
+		Preferences.set(AUTO_BUILDING_PLUGIN, AUTO_BUILDING_KEY, "true");
+	}
+
+	/**
+	 * Sets the auto building off.
+	 */
+	public static void setAutoBuildingOff() {
+		log.info("Setting the auto building OFF.");
+		Preferences.set(AUTO_BUILDING_PLUGIN, AUTO_BUILDING_KEY, "false");
+	}
+}

--- a/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat
-Export-Package: org.jboss.reddeer.requirements.cleanworkspace,
+Export-Package: org.jboss.reddeer.requirements.autobuilding,
+ org.jboss.reddeer.requirements.cleanworkspace,
  org.jboss.reddeer.requirements.closeeditors,
  org.jboss.reddeer.requirements.db,
  org.jboss.reddeer.requirements.exception,

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/autobuilding/AutoBuildingRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/autobuilding/AutoBuildingRequirement.java
@@ -1,0 +1,58 @@
+package org.jboss.reddeer.requirements.autobuilding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jboss.reddeer.direct.preferences.PreferencesUtil;
+import org.jboss.reddeer.junit.requirement.Requirement;
+import org.jboss.reddeer.requirements.autobuilding.AutoBuildingRequirement.AutoBuilding;
+
+/**
+ * This requirement ensures that the setting for auto building is set on/off.
+ * During the cleanup phase the change is set back.
+ * 
+ * @author Andrej Podhradsky
+ *
+ */
+public class AutoBuildingRequirement implements Requirement<AutoBuilding> {
+
+	private AutoBuilding autoBuilding;
+	private boolean autoBuildingOriginalValue;
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public @interface AutoBuilding {
+		boolean value() default true;
+	}
+
+	@Override
+	public boolean canFulfill() {
+		return true;
+	}
+
+	@Override
+	public void fulfill() {
+		autoBuildingOriginalValue = PreferencesUtil.isAutoBuildingOn();
+		if (autoBuilding.value()) {
+			PreferencesUtil.setAutoBuildingOn();
+		} else {
+			PreferencesUtil.setAutoBuildingOff();
+		}
+	}
+
+	@Override
+	public void setDeclaration(AutoBuilding autoBuilding) {
+		this.autoBuilding = autoBuilding;
+	}
+
+	@Override
+	public void cleanUp() {
+		if (autoBuildingOriginalValue) {
+			PreferencesUtil.setAutoBuildingOn();
+		} else {
+			PreferencesUtil.setAutoBuildingOff();
+		}
+	}
+}

--- a/tests/org.jboss.reddeer.direct.test/src/org/jboss/reddeer/direct/test/preferences/PreferencesTest.java
+++ b/tests/org.jboss.reddeer.direct.test/src/org/jboss/reddeer/direct/test/preferences/PreferencesTest.java
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith;
 /**
  * Test for core manipulation with Eclipse preferences.
  * 
- * @author apodhrad
+ * @author Andrej Podhradsky
  * 
  */
 @CleanWorkspace

--- a/tests/org.jboss.reddeer.direct.test/src/org/jboss/reddeer/direct/test/preferences/PreferencesUtilTest.java
+++ b/tests/org.jboss.reddeer.direct.test/src/org/jboss/reddeer/direct/test/preferences/PreferencesUtilTest.java
@@ -1,0 +1,32 @@
+package org.jboss.reddeer.direct.test.preferences;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.reddeer.direct.preferences.PreferencesUtil;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.api.Menu;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for core manipulation with common preferences.
+ * 
+ * @author Andrej Podhradsky
+ * 
+ */
+@RunWith(RedDeerSuite.class)
+public class PreferencesUtilTest {
+
+	@Test
+	public void autoBuildingTest() {
+		Menu menu = new ShellMenu("Project", "Build Automatically");
+		assertEquals(menu.isSelected(), PreferencesUtil.isAutoBuildingOn());
+		PreferencesUtil.setAutoBuildingOff();
+		assertEquals(menu.isSelected(), false);
+		assertEquals(menu.isSelected(), PreferencesUtil.isAutoBuildingOn());
+		PreferencesUtil.setAutoBuildingOn();
+		assertEquals(menu.isSelected(), true);
+		assertEquals(menu.isSelected(), PreferencesUtil.isAutoBuildingOn());
+	}
+}

--- a/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/autobuilding/AutoBuildingRequirementOffTest.java
+++ b/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/autobuilding/AutoBuildingRequirementOffTest.java
@@ -1,0 +1,25 @@
+package org.jboss.reddeer.requirements.test.autobuilding;
+
+import static org.junit.Assert.assertFalse;
+
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.requirements.autobuilding.AutoBuildingRequirement.AutoBuilding;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * 
+ * @author Andrej Podhradsky
+ *
+ */
+@AutoBuilding(false)
+@RunWith(RedDeerSuite.class)
+public class AutoBuildingRequirementOffTest {
+
+	@Test
+	public void autoBuildRequirementOffTest() {
+		assertFalse(new ShellMenu("Project", "Build Automatically").isSelected());
+	}
+
+}

--- a/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/autobuilding/AutoBuildingRequirementOnTest.java
+++ b/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/autobuilding/AutoBuildingRequirementOnTest.java
@@ -1,0 +1,25 @@
+package org.jboss.reddeer.requirements.test.autobuilding;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.requirements.autobuilding.AutoBuildingRequirement.AutoBuilding;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * 
+ * @author Andrej Podhradsky
+ *
+ */
+@AutoBuilding(true)
+@RunWith(RedDeerSuite.class)
+public class AutoBuildingRequirementOnTest {
+
+	@Test
+	public void autoBuildRequirementOnTest() {
+		assertTrue(new ShellMenu("Project", "Build Automatically").isSelected());
+	}
+
+}

--- a/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/autobuilding/AutoBuildingRequirementTest.java
+++ b/tests/org.jboss.reddeer.requirements.test/src/org/jboss/reddeer/requirements/test/autobuilding/AutoBuildingRequirementTest.java
@@ -1,0 +1,53 @@
+package org.jboss.reddeer.requirements.test.autobuilding;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.reddeer.direct.preferences.PreferencesUtil;
+import org.jboss.reddeer.junit.internal.configuration.NullTestRunConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
+import org.jboss.reddeer.junit.internal.requirement.Requirements;
+import org.jboss.reddeer.junit.internal.requirement.RequirementsBuilder;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.requirements.autobuilding.AutoBuildingRequirement.AutoBuilding;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * 
+ * @author Andrej Podhradsky
+ *
+ */
+@AutoBuilding(false)
+@RunWith(RedDeerSuite.class)
+public class AutoBuildingRequirementTest {
+
+	@Test
+	public void autoBuildRequirementOnCleanUpTest() {
+		PreferencesUtil.setAutoBuildingOff();
+		Requirements requirements = getRequirements(AutoBuildingRequirementOnTest.class);
+		assertTrue(requirements.canFulfill());
+		requirements.fulfill();
+		assertTrue(PreferencesUtil.isAutoBuildingOn());
+		requirements.cleanUp();
+		assertFalse(PreferencesUtil.isAutoBuildingOn());
+	}
+
+	@Test
+	public void autoBuildRequirementOffCleanUpTest() {
+		PreferencesUtil.setAutoBuildingOn();
+		Requirements requirements = getRequirements(AutoBuildingRequirementOffTest.class);
+		assertTrue(requirements.canFulfill());
+		requirements.fulfill();
+		assertFalse(PreferencesUtil.isAutoBuildingOn());
+		requirements.cleanUp();
+		assertTrue(PreferencesUtil.isAutoBuildingOn());
+	}
+
+	private Requirements getRequirements(Class<?> klass) {
+		RequirementsBuilder reqBuilder = new RequirementsBuilder();
+		TestRunConfiguration config = new NullTestRunConfiguration();
+		return reqBuilder.build(klass, config.getRequirementConfiguration(), config.getId());
+	}
+
+}


### PR DESCRIPTION
Something like
```java
@AutoBuilding(false)
@RunwWith(RedDeerSuite.class)
public class testWithoutAutoBuild {
...
}
```

note that the auto building is disabled only for the test class, then it is set back to its original value.