### PR TITLE
org.jboss.reddeer.eclipse.test.debug.ui.launchConfigurations.RunConfigurationDialogTest.createSelectDelete failed

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/debug/ui/launchConfigurations/LaunchConfigurationDialog.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/debug/ui/launchConfigurations/LaunchConfigurationDialog.java
@@ -1,11 +1,17 @@
 package org.jboss.reddeer.eclipse.debug.ui.launchConfigurations;
 
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.jboss.reddeer.common.exception.RedDeerException;
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.JobIsRunning;
 import org.jboss.reddeer.core.condition.ShellWithTextIsActive;
+import org.jboss.reddeer.core.handler.WidgetHandler;
+import org.jboss.reddeer.core.lookup.ShellLookup;
+import org.jboss.reddeer.core.lookup.WidgetLookup;
 import org.jboss.reddeer.swt.api.Button;
 import org.jboss.reddeer.swt.api.Menu;
 import org.jboss.reddeer.swt.api.TreeItem;
@@ -91,7 +97,38 @@ public abstract class LaunchConfigurationDialog {
 		TreeItem t = new DefaultTreeItem(configuration.getType());
 		t.select();
 
-		new ContextMenu("New").select();
+		log.info("Wait until");
+		new WaitUntil(new JobIsRunning(), TimePeriod.SHORT, false);
+		log.info("Wait while");
+		new WaitWhile(new JobIsRunning(), TimePeriod.NORMAL);
+		
+		log.info("Active shells:");
+		for (Shell shell : ShellLookup.getInstance().getShells()){
+			log.info("\t" + WidgetHandler.getInstance().getText(shell));
+		}
+		
+		log.info("Default shell: " + new DefaultShell(getTitle()));
+		log.info("Focused control: " + WidgetLookup.getInstance().getFocusControl());
+		Control c = WidgetLookup.getInstance().getFocusControl();
+		if (c instanceof Shell){
+			log.info("Focused control is shell: " + WidgetHandler.getInstance().getText(c));
+		}
+		
+		log.info("Select tree item again");
+		t.select();
+		
+		log.info("Focused control: " + WidgetLookup.getInstance().getFocusControl());
+		c = WidgetLookup.getInstance().getFocusControl();
+		if (c instanceof Shell){
+			log.info("Focused control is shell: " + WidgetHandler.getInstance().getText(c));
+		}
+		try {
+			new ContextMenu("New").select();
+		} catch (RedDeerException e){
+			log.error("Error: " + new DefaultShell().getText());
+			new WaitWhile(new JobIsRunning(), TimePeriod.NONE);
+			throw e;
+		}
 		if (name != null){
 			configuration.setName(name);
 			configuration.apply();


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_master_matrix/jdk=sunjdk1.7,label=stable-windows/740/testReport/junit/org.jboss.reddeer.eclipse.test.debug.ui.launchConfigurations/RunConfigurationDialogTest/createSelectDelete_default/?

Error Message

class org.eclipse.jface.dialogs.ProgressIndicator Has no menu
Stacktrace

org.jboss.reddeer.core.exception.CoreLayerException: class org.eclipse.jface.dialogs.ProgressIndicator Has no menu
	at org.jboss.reddeer.core.lookup.MenuLookup.getControlMenu(MenuLookup.java:328)
	at org.jboss.reddeer.core.lookup.MenuLookup.getTopMenuMenuItemsFromFocus(MenuLookup.java:195)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:45)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:34)
	at org.jboss.reddeer.eclipse.debug.ui.launchConfigurations.LaunchConfigurationDialog.create(LaunchConfigurationDialog.java:94)
	at org.jboss.reddeer.eclipse.test.debug.ui.launchConfigurations.AbstractLaunchConfigurationDialogTest.createSelectDelete(AbstractLaunchConfigurationDialogTest.java:46)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.jboss.reddeer.junit.internal.runner.statement.RunTestMethod.evaluate(RunTestMethod.java:25)
	at org.jboss.reddeer.junit.internal.runner.statement.RunBefores.evaluate(RunBefores.java:48)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIBeforeTestExtensions.evaluate(RunIBeforeTestExtensions.java:50)
	at org.jboss.reddeer.junit.internal.runner.statement.RunAfters.evaluate(RunAfters.java:37)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIAfterTestExtensions.evaluate(RunIAfterTestExtensions.java:38)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:127)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.jboss.reddeer.junit.internal.runner.statement.RunBefores.evaluate(RunBefores.java:48)
	at org.jboss.reddeer.junit.internal.runner.statement.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:26)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIBeforeClassExtensions.evaluate(RunIBeforeClassExtensions.java:49)
	at org.jboss.reddeer.junit.internal.runner.statement.RunAfters.evaluate(RunAfters.java:37)
	at org.jboss.reddeer.junit.internal.runner.statement.CleanUpRequirementStatement.evaluate(CleanUpRequirementStatement.java:25)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIAfterClassExtensions.evaluate(RunIAfterClassExtensions.java:37)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:111)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)