### PR TITLE
org.jboss.reddeer.swt.test.impl.combo.ComboTest.enabled failed

### DIFF
--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/SWTLayerTestCase.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/SWTLayerTestCase.java
@@ -1,9 +1,10 @@
 package org.jboss.reddeer.swt.test;
 
 import org.eclipse.swt.widgets.Shell;
-import org.jboss.reddeer.junit.runner.RedDeerSuite;
-import org.jboss.reddeer.swt.test.utils.ShellTestUtils;
 import org.jboss.reddeer.core.util.Display;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.jboss.reddeer.swt.test.utils.ShellTestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -25,6 +26,7 @@ public abstract class SWTLayerTestCase {
 				shell.layout();
 			}
 		});
+		new DefaultShell(SHELL_TITLE);
 	}
 	
 	@After


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_master_matrix/jdk=sunjdk1.7,label=stable-linux/739/testReport/junit/org.jboss.reddeer.swt.test.impl.combo/ComboTest/enabled_default/?

Error Message

No matching widget found with Matcher matching when all matchers match: [Matcher matching widget with the same type as or type extending class org.eclipse.swt.widgets.Combo]
class org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer$2
 class org.eclipse.swt.widgets.Composite
  class org.eclipse.swt.widgets.Label with text 'Name:'
  class org.eclipse.swt.widgets.Text with label 'Name:' with text 'Original text'
  class org.eclipse.swt.custom.StyledText with label 'Name:' with text 'Styled text'
Stacktrace

org.jboss.reddeer.core.exception.CoreLayerException: No matching widget found with Matcher matching when all matchers match: [Matcher matching widget with the same type as or type extending class org.eclipse.swt.widgets.Combo]
class org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer$2
	class org.eclipse.swt.widgets.Composite
		class org.eclipse.swt.widgets.Label with text 'Name:'
		class org.eclipse.swt.widgets.Text with label 'Name:' with text 'Original text'
		class org.eclipse.swt.custom.StyledText with label 'Name:' with text 'Styled text'

	at org.jboss.reddeer.common.wait.AbstractWait.timeoutExceeded(AbstractWait.java:173)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:126)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:91)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:61)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:46)
	at org.jboss.reddeer.common.wait.WaitUntil.<init>(WaitUntil.java:37)
	at org.jboss.reddeer.core.lookup.WidgetLookup.activeWidget(WidgetLookup.java:76)
	at org.jboss.reddeer.swt.widgets.AbstractWidget.<init>(AbstractWidget.java:31)
	at org.jboss.reddeer.swt.impl.combo.AbstractCombo.<init>(AbstractCombo.java:28)
	at org.jboss.reddeer.swt.impl.combo.DefaultCombo.<init>(DefaultCombo.java:87)
	at org.jboss.reddeer.swt.impl.combo.DefaultCombo.<init>(DefaultCombo.java:76)
	at org.jboss.reddeer.swt.test.impl.combo.ComboTest.enabled(ComboTest.java:105)
