### PR TITLE
rawagner_org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.testSQLResultViewFail default

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/sqltools/result/ui/ResultView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/sqltools/result/ui/ResultView.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.reddeer.common.platform.RunningPlatform;
+import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.swt.api.TreeItem;
 import org.jboss.reddeer.swt.condition.TreeHasChildren;
@@ -52,6 +54,7 @@ public class ResultView extends WorkbenchView {
 	public void removeAllResults() {
 		open();
 		DefaultTree tree = new DefaultTree();
+		new WaitUntil(new TreeHasChildren(tree),TimePeriod.NORMAL, false);
 		String tooltip = "Remove All Visible Results (Shift+Delete)";
 		if (RunningPlatform.isOSX()) {
 			tooltip = "Remove All Visible Results (⇧⌦)";


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_master_matrix/jdk=sunjdk1.7,label=stable-linux/753/testReport/junit/org.jboss.reddeer.eclipse.test.datatools.ui/ResultViewTest/testSQLResultViewFail_default/

Error Message

Timeout after: 10 s.: tree has children
Stacktrace

org.jboss.reddeer.common.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: tree has children
	at org.jboss.reddeer.common.wait.AbstractWait.timeoutExceeded(AbstractWait.java:173)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:126)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:91)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:61)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:46)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:34)
	at org.jboss.reddeer.common.wait.WaitWhile.<init>(WaitWhile.java:24)
	at org.jboss.reddeer.eclipse.datatools.sqltools.result.ui.ResultView.removeAllResults(ResultView.java:61)
	at org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.removeResults(ResultViewTest.java:214)
	at org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.testSQLResultView(ResultViewTest.java:183)
	at org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.testSQLResultViewFail(ResultViewTest.java:173)