### PR TITLE
CoreLayerException in Code Generator

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
@@ -213,7 +213,7 @@ public class WidgetHandler {
 				List<Control> allWidgets = WidgetLookup.getInstance().findAllParentWidgets();
 				int widgetIndex = allWidgets.indexOf(w);
 				if (widgetIndex < 0) {
-					throw new CoreLayerException("Wrong implementation for finding labels!");
+					return null;
 				}
 				ListIterator<? extends Widget> listIterator = allWidgets.listIterator(widgetIndex);
 				while (listIterator.hasPrevious()) {


### PR DESCRIPTION
org.jboss.reddeer.core.exception.CoreLayerException: Exception during sync execution in UI thread
	at org.jboss.reddeer.core.util.Display.syncExec(Display.java:87)
	at org.jboss.reddeer.core.handler.WidgetHandler.getLabel(WidgetHandler.java:190)
	at org.jboss.reddeer.generator.TextCodeGenerator.getGeneratedCode(TextCodeGenerator.java:45)
	at org.jboss.reddeer.generator.views.CodeGeneratorView.generateCode(CodeGeneratorView.java:113)
	at org.jboss.reddeer.generator.views.CodeGeneratorView$1.handleEvent(CodeGeneratorView.java:93)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
	at org.eclipse.swt.widgets.Display.filterEvent(Display.java:1550)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1328)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1353)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1338)
	at org.eclipse.swt.widgets.Widget.sendKeyEvent(Widget.java:1365)
	at org.eclipse.swt.widgets.Widget.gtk_key_press_event(Widget.java:763)
	at org.eclipse.swt.widgets.Control.gtk_key_press_event(Control.java:3317)
	at org.eclipse.swt.widgets.Text.gtk_key_press_event(Text.java:1810)
	at org.eclipse.swt.widgets.Widget.windowProc(Widget.java:1980)
	at org.eclipse.swt.widgets.Control.windowProc(Control.java:5590)
	at org.eclipse.swt.widgets.Text.windowProc(Text.java:2767)
	at org.eclipse.swt.widgets.Display.windowProc(Display.java:4717)
	at org.eclipse.swt.internal.gtk.OS._gtk_main_do_event(Native Method)
	at org.eclipse.swt.internal.gtk.OS.gtk_main_do_event(OS.java:9279)
	at org.eclipse.swt.widgets.Display.eventProc(Display.java:1225)
	at org.eclipse.swt.internal.gtk.OS._g_main_context_iteration(Native Method)
	at org.eclipse.swt.internal.gtk.OS.g_main_context_iteration(OS.java:2425)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3428)
	at org.eclipse.jface.window.Window.runEventLoop(Window.java:827)
	at org.eclipse.jface.window.Window.open(Window.java:803)
	at org.eclipse.ui.actions.NewProjectAction.run(NewProjectAction.java:115)
	at org.eclipse.jface.action.Action.runWithEvent(Action.java:473)
	at org.eclipse.jface.action.ActionContributionItem.handleWidgetSelection(ActionContributionItem.java:595)
	at org.eclipse.jface.action.ActionContributionItem.access$2(ActionContributionItem.java:511)
	at org.eclipse.jface.action.ActionContributionItem$5.handleEvent(ActionContributionItem.java:420)
	at org.eclipse.swt.widgets.EventTable.sendEvent(EventTable.java:84)
	at org.eclipse.swt.widgets.Display.sendEvent(Display.java:4481)
	at org.eclipse.swt.widgets.Widget.sendEvent(Widget.java:1329)
	at org.eclipse.swt.widgets.Display.runDeferredEvents(Display.java:3819)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3430)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
Caused by: org.jboss.reddeer.core.exception.CoreLayerException: Wrong implementation for finding labels!
	at org.jboss.reddeer.core.handler.WidgetHandler$3.run(WidgetHandler.java:216)
	at org.jboss.reddeer.core.handler.WidgetHandler$3.run(WidgetHandler.java:1)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:160)
	at org.jboss.reddeer.core.util.Display.syncExec(Display.java:83)
	... 57 more