### PR TITLE
rev_org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.testSQLResultViewSuccess failed

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/sqltools/result/ui/ResultView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/datatools/sqltools/result/ui/ResultView.java
@@ -61,7 +61,7 @@ public class ResultView extends WorkbenchView {
 		}
 		DefaultToolItem item = new DefaultToolItem(tooltip);
 		item.click();
-		new WaitWhile(new TreeHasChildren(tree));
+		new WaitWhile(new TreeHasChildren(tree), TimePeriod.LONG);
 	}
 
 }


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_master_matrix/jdk=sunjdk1.7,label=stable-linux/768/testReport/junit/org.jboss.reddeer.eclipse.test.datatools.ui/ResultViewTest/testSQLResultViewSuccess_default/

Error Message

Timeout after: 10 s.: tree has children
Stacktrace

org.jboss.reddeer.common.exception.WaitTimeoutExpiredException: Timeout after: 10 s.: tree has children
	at org.jboss.reddeer.common.wait.AbstractWait.timeoutExceeded(AbstractWait.java:173)
	at org.jboss.reddeer.common.wait.AbstractWait.wait(AbstractWait.java:126)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:91)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:61)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:46)
	at org.jboss.reddeer.common.wait.AbstractWait.<init>(AbstractWait.java:34)
	at org.jboss.reddeer.common.wait.WaitWhile.<init>(WaitWhile.java:24)
	at org.jboss.reddeer.eclipse.datatools.sqltools.result.ui.ResultView.removeAllResults(ResultView.java:64)
	at org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.removeResults(ResultViewTest.java:214)
	at org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.testSQLResultView(ResultViewTest.java:183)
	at org.jboss.reddeer.eclipse.test.datatools.ui.ResultViewTest.testSQLResultViewSuccess(ResultViewTest.java:178)
