### PR TITLE
Cannot install RedDeer UI into Luna

### DIFF
--- a/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
@@ -22,6 +22,6 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.common;bundle-version="[1.0,1.1)",
  org.eclipse.core.variables;bundle-version="3.2.800",
  org.eclipse.jdt.debug.ui;bundle-version="3.6.0",
- org.eclipse.jdt.ui;bundle-version="3.11.0",
- org.eclipse.ui.ide;bundle-version="3.11.0"
+ org.eclipse.jdt.ui;bundle-version="3.10.2",
+ org.eclipse.ui.ide;bundle-version="3.10.2"
 


### PR DESCRIPTION
Cannot complete the install because one or more required items could not be found.
  Software being installed: RedDeer UI Feature 1.0.0.Final (org.jboss.reddeer.ui.feature.feature.group 1.0.0.Final)
  Missing requirement: RedDeer UI Component 1.0.0.Final (org.jboss.reddeer.ui 1.0.0.Final) requires 'bundle org.eclipse.jdt.ui 3.11.0' but it could not be found
  Cannot satisfy dependency:
    From: RedDeer UI Feature 1.0.0.Final (org.jboss.reddeer.ui.feature.feature.group 1.0.0.Final)
    To: org.jboss.reddeer.ui [1.0.0.Final]