### PR TITLE
Add support for Arquillian and Arquillian Validator pages to Red Deer 

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.reddeer.eclipse,
+ org.jboss.reddeer.eclipse.arquillian.ui.preferences,
  org.jboss.reddeer.eclipse.condition,
  org.jboss.reddeer.eclipse.core.resources,
  org.jboss.reddeer.eclipse.datatools.sqltools.result.ui,
@@ -79,4 +80,5 @@ Export-Package: org.jboss.reddeer.eclipse,
  org.jboss.reddeer.eclipse.wst.web.ui.wizards,
  org.jboss.reddeer.eclipse.wst.xml.ui.tabletree
 Import-Package: org.eclipse.ui.internal.views.markers,
+ org.jboss.reddeer.uiforms.impl.formtext,
  org.junit

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/arquillian/ui/preferences/ArquillianPreferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/arquillian/ui/preferences/ArquillianPreferencePage.java
@@ -1,0 +1,209 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.eclipse.arquillian.ui.preferences;
+
+import org.jboss.reddeer.jface.preference.PreferencePage;
+import org.jboss.reddeer.swt.impl.button.CheckBox;
+import org.jboss.reddeer.swt.impl.combo.LabeledCombo;
+import org.jboss.reddeer.swt.impl.table.DefaultTable;
+import org.jboss.reddeer.swt.impl.text.DefaultText;
+
+/**
+ * Class represents Arquillian preference page
+ * 
+ * @author Vlado Pakan, Len DiMaggio
+ *
+ */
+public class ArquillianPreferencePage extends PreferencePage {
+
+	private static final String ARQUILLIAN_VERSION = "Arquillian version:";
+	private static final String ENABLE_DEFAULT_VM_ARGUMENTS = "Enable default VM arguments";
+	private static final String ADD_DEFAULT_VM_ARGS_TO_JUNIT_LAUNCH = "Add the default VM arguments to the JUnit/TestNG launch configurations";
+	private static final String ADD_DEFAULT_VM_ARGS_TO_LAUNCH = "Add the default VM arguments to the existing launch configurations";
+	private static final String ALLOW_OS_COMMAND_WHEN_ANALYZING = "Allow running an OS command when analyzing a deployment method";
+	/* https://issues.jboss.org/browse/JBIDE-21632 */
+	private static final String ALLOW_SYS_PROPERTY_WHEN_ANALYZING = "Allow setting a system propery when analyzing a deployment method";
+
+	/**
+	 * Constructs the preference page with "Arquillian".
+	 */
+	public ArquillianPreferencePage() {
+		super(new String[] { "JBoss Tools", "Arquillian" });
+	}
+
+	/**
+	 * Returns true when "Enable default VM arguments" checkbox is checked.
+	 *
+	 * @return true, if is checked
+	 */
+	public boolean isDefaultVMArgChecked() {
+		return new CheckBox(ArquillianPreferencePage.ENABLE_DEFAULT_VM_ARGUMENTS).isChecked();
+	}
+
+	/**
+	 * Sets "Enable default VM arguments" checkbox.
+	 *
+	 * @param check the checkbox
+	 */
+	public void setDefaultVMArg(boolean check) {
+		new CheckBox(ArquillianPreferencePage.ENABLE_DEFAULT_VM_ARGUMENTS).toggle(check);
+	}
+
+	/**
+	 * Returns the current selection in the "Arquillian version:" combo
+	 * 
+	 * @return Arquillian version string
+	 */
+	public String getArquillianVersion() {
+		return (new LabeledCombo(ARQUILLIAN_VERSION).getSelection());
+	}
+
+	/**
+	 * Sets the "Arquillian version:" in the combo
+	 * 
+	 * @param The version string to be selected
+	 */
+	public void setArquillianVersion(String versionString) {
+		new LabeledCombo(ARQUILLIAN_VERSION).setSelection(versionString);
+	}
+
+	/**
+	 * Returns the defined VM arguments
+	 * 
+	 * @return VM arguments String
+	 */
+	public String getVMArgsText() {
+		return (new DefaultText(1).getText());
+	}
+
+	/**
+	 * Sets the VM arguments
+	 * 
+	 * @param The arguments String
+	 */
+	public void setVMArgsText(String argString) {
+		new DefaultText(1).setText(argString);
+	}
+
+	/**
+	 * Returns true when
+	 * "Add the default VM arguments to the JUnit/TestNG launch configurations"
+	 * checkbox is checked.
+	 *
+	 * @return true, if is checked
+	 */
+	public boolean isAddDefaultVMArgsToJUnitChecked() {
+		return new CheckBox(ArquillianPreferencePage.ADD_DEFAULT_VM_ARGS_TO_JUNIT_LAUNCH).isChecked();
+	}
+
+	/**
+	 * Sets
+	 * "Add the default VM arguments to the JUnit/TestNG launch configurations"
+	 * checkbox.
+	 *
+	 * @param check the checkbox
+	 */
+	public void setDefaultVMArgsToJUnit(boolean check) {
+		new CheckBox(ArquillianPreferencePage.ADD_DEFAULT_VM_ARGS_TO_JUNIT_LAUNCH).toggle(check);
+	}
+
+	/**
+	 * Returns true when
+	 * "Add the default VM arguments to the existing launch configurations"
+	 * checkbox is checked.
+	 *
+	 * @return true, if is checked
+	 */
+	public boolean isAddDefaultVMArgsToLaunchChecked() {
+		return new CheckBox(ArquillianPreferencePage.ADD_DEFAULT_VM_ARGS_TO_LAUNCH).isChecked();
+	}
+
+	/**
+	 * Sets "Add the default VM arguments to the existing launch configurations"
+	 * checkbox.
+	 *
+	 * @param check the checkbox
+	 */
+	public void setDefaultVMArgsToLaunch(boolean check) {
+		new CheckBox(ArquillianPreferencePage.ADD_DEFAULT_VM_ARGS_TO_LAUNCH).toggle(check);
+	}
+
+	/**
+	 * Returns true when
+	 * "Allow running an OS command when analyzing a deployment method" checkbox
+	 * is checked.
+	 *
+	 * @return true, if is checked
+	 */
+	public boolean isAllowOSCommandWhenAnalyzingChecked() {
+		return new CheckBox(ArquillianPreferencePage.ALLOW_OS_COMMAND_WHEN_ANALYZING).isChecked();
+	}
+
+	/**
+	 * Sets "Allow running an OS command when analyzing a deployment method"
+	 * checkbox.
+	 *
+	 * @param check the checkbox
+	 */
+	public void setAllowOSCommandWhenAnalyzing(boolean check) {
+		new CheckBox(ArquillianPreferencePage.ALLOW_OS_COMMAND_WHEN_ANALYZING).toggle(check);
+	}
+
+	/**
+	 * Returns true when
+	 * "Allow setting a system property when analyzing a deployment method"
+	 * checkbox is checked.
+	 *
+	 * @return true, if is checked
+	 */
+	public boolean isAllowSystemPropWhenAnalyzingChecked() {
+		return new CheckBox(ArquillianPreferencePage.ALLOW_SYS_PROPERTY_WHEN_ANALYZING).isChecked();
+	}
+
+	/**
+	 * Sets "Allow setting a system property when analyzing a deployment method"
+	 * checkbox.
+	 *
+	 * @param check the checkbox
+	 */
+	public void setAllowSystemPropWhenAnalyzing(boolean check) {
+		new CheckBox(ArquillianPreferencePage.ALLOW_SYS_PROPERTY_WHEN_ANALYZING).toggle(check);
+	}
+
+	/**
+	 * Sets the checkbox on the selected item in the profiles table
+	 * 
+	 * @param profileName
+	 */
+	public void checkSelectedProfileCheckBox(String profileName) {
+		new DefaultTable().getItem(profileName).setChecked(true);
+	}
+
+	/**
+	 * Un-set the checkbox on the selected item in the profiles table
+	 * 
+	 * @param profileName
+	 */
+	public void unCheckSelectedProfileCheckBox(String profileName) {
+		new DefaultTable().getItem(profileName).setChecked(false);
+	}
+
+	/**
+	 * Return the status of the checkbox on the selected item in the profiles
+	 * table
+	 * 
+	 * @return true, if is checked
+	 */
+	public boolean isSelectedProfileChecked(String profileName) {
+		return new DefaultTable().getItem(profileName).isChecked();
+	}
+
+}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/arquillian/ui/preferences/ArquillianValidatorPreferencePage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/arquillian/ui/preferences/ArquillianValidatorPreferencePage.java
@@ -1,0 +1,245 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.eclipse.arquillian.ui.preferences;
+
+import org.jboss.reddeer.jface.preference.PreferencePage;
+import org.jboss.reddeer.swt.impl.button.CheckBox;
+import org.jboss.reddeer.swt.impl.combo.LabeledCombo;
+import org.jboss.reddeer.swt.impl.text.LabeledText;
+
+/**
+ * Class represents Arquillian preference page
+ * 
+ * @author Vlado Pakan, Len DiMaggio
+ *
+ */
+public class ArquillianValidatorPreferencePage extends PreferencePage {
+
+	private static final String TEST_ARQUILLIAN_CONTAINER = "Test Arquillian Container";
+	private static final String ENABLE_VALIDATION = "Enable Validation";
+	private static final String SELECT_SEVERITY_LEVEL = "Select the severity level for the following optional problems:";
+	private static final String MISSING_DEPLOY_METHOD = "Missing @Deployment method";
+	private static final String MISSING_TEST_METHOD = "Missing @Test method";
+	private static final String TYPE_NOT_INCLUDED = "Type is not included in any deployment";
+	private static final String IMPORT_NOT_INCLUDED = "Import is not included in any deployment";
+	private static final String DEPLOY_ARCHIVE_NOT_INCLUDED = "Deployment archive cannot be created";
+	private static final String INVALID_ARCHIVE_NAME = "Invalid archive name";
+	private static final String DEPLOY_METHOD_PUBLIC_STATIC = "Deployment method has to be public and static";
+	private static final String INVALID_ARCHIVE_FILE_LOCATION = "Invalid archive file location";
+
+	/**
+	 * Constructs the preference page with "Arquillian".
+	 */
+	public ArquillianValidatorPreferencePage() {
+		super(new String[] { "JBoss Tools", "Arquillian", "Arquillian Validator" });
+	}
+
+	/**
+	 * Returns true when "Test Arquillian Container" checkbox is checked.
+	 *
+	 * @return true, if is checked
+	 */
+	public boolean isTestArquillianContainerChecked() {
+		return new CheckBox(ArquillianValidatorPreferencePage.TEST_ARQUILLIAN_CONTAINER).isChecked();
+	}
+
+	/**
+	 * Sets "Test Arquillian Container" checkbox.
+	 *
+	 * @param the checkbox
+	 */
+	public void setTestArquillianContainer(boolean check) {
+		new CheckBox(ArquillianValidatorPreferencePage.TEST_ARQUILLIAN_CONTAINER).toggle(check);
+	}
+
+	/**
+	 * Returns true when "Enable Validation" checkbox is checked.
+	 *
+	 * @return true, if is checked
+	 */
+	public boolean isTestEnableValidationChecked() {
+		return new CheckBox(ArquillianValidatorPreferencePage.ENABLE_VALIDATION).isChecked();
+	}
+
+	/**
+	 * Sets "Enable Validation" checkbox.
+	 *
+	 * @param the checkbox
+	 */
+	public void setEnableValidation(boolean check) {
+		new CheckBox(ArquillianValidatorPreferencePage.ENABLE_VALIDATION).toggle(check);
+	}
+	
+	/**
+	 * Returns the current selection in the "Select the severity level for the following optional problems" labeled text
+	 * 
+	 * @return Arquillian string
+	 */
+	public String getSelectedSeverity () {
+		return (new LabeledText(SELECT_SEVERITY_LEVEL).getText());
+	}
+
+	/**
+	 * Sets the "Select the severity level for the following optional problems" in the labeled text
+	 * 
+	 * @param The string to be set
+	 */
+	public void setSelectedSeverity(String filterString) {
+		new LabeledText(SELECT_SEVERITY_LEVEL).setText(filterString);
+	}
+	
+	/**
+	 * Returns the current selection in the "Missing @Deployment method" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getDeploymentMethod () {
+		return (new LabeledCombo(MISSING_DEPLOY_METHOD).getSelection());
+	}
+
+	/**
+	 * Sets the "Missing @Deployment method" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setDeploymentMethod (String severityString) {
+		new LabeledCombo(MISSING_DEPLOY_METHOD).setSelection(severityString);
+	}
+		
+	/**
+	 * Returns the current selection in the "Missing @Test method" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getMissingTestMethod () {
+		return (new LabeledCombo(MISSING_TEST_METHOD).getSelection());
+	}
+
+	/**
+	 * Sets the "Missing @Test method" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setMissingTestMethod (String severityString) {
+		new LabeledCombo(MISSING_TEST_METHOD).setSelection(severityString);
+	}
+	
+	/**
+	 * Returns the current selection in the "Type is not included in any deployment" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getTypeNotIncluded () {
+		return (new LabeledCombo(TYPE_NOT_INCLUDED).getSelection());
+	}
+
+	/**
+	 * Sets the "Type is not included in any deployment" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setTypeNotIncluded (String severityString) {
+		new LabeledCombo(TYPE_NOT_INCLUDED).setSelection(severityString);
+	}
+	
+	
+	/**
+	 * Returns the current selection in the "Import is not included in any deployment" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getImportNotIncluded () {
+		return (new LabeledCombo(IMPORT_NOT_INCLUDED).getSelection());
+	}
+
+	/**
+	 * Sets the "Import is not included in any deployment" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setImportNotIncluded (String severityString) {
+		new LabeledCombo(IMPORT_NOT_INCLUDED).setSelection(severityString);
+	}
+	
+	
+	/**
+	 * Returns the current selection in the "Deployment archive cannot be created" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getDeployArchiveNotIncluded () {
+		return (new LabeledCombo(DEPLOY_ARCHIVE_NOT_INCLUDED).getSelection());
+	}
+
+	/**
+	 * Sets the "Deployment archive cannot be created" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setDeployArchiveNotIncluded (String severityString) {
+		new LabeledCombo(DEPLOY_ARCHIVE_NOT_INCLUDED).setSelection(severityString);
+	}
+	
+	/**
+	 * Returns the current selection in the "Invalid archive name" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getInvalidArchiveName () {
+		return (new LabeledCombo(INVALID_ARCHIVE_NAME).getSelection());
+	}
+
+	/**
+	 * Sets the "Invalid archive name" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setInvalidArchiveName (String severityString) {
+		new LabeledCombo(INVALID_ARCHIVE_NAME).setSelection(severityString);
+	}
+	
+	/**
+	 * Returns the current selection in the "Deployment method has to be public and static" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getDeployMethodPublicStatic () {
+		return (new LabeledCombo(DEPLOY_METHOD_PUBLIC_STATIC).getSelection());
+	}
+
+	/**
+	 * Sets the "Deployment method has to be public and static" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setDeployMethodPublicStatic (String severityString) {
+		new LabeledCombo(DEPLOY_METHOD_PUBLIC_STATIC).setSelection(severityString);
+	}
+	
+	/**
+	 * Returns the current selection in the "Invalid archive file location" combo
+	 * 
+	 * @return Arquillian combo selection string
+	 */
+	public String getInvalidArchiveFileLocation () {
+		return (new LabeledCombo(INVALID_ARCHIVE_FILE_LOCATION).getSelection());
+	}
+
+	/**
+	 * Sets the "Invalid archive file location" combo
+	 * 
+	 * @param The string to be selected
+	 */
+	public void setInvalidArchiveFileLocation (String severityString) {
+		new LabeledCombo(INVALID_ARCHIVE_FILE_LOCATION).setSelection(severityString);
+	}
+	
+}

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/arquillian/ui/preferences/ArquillianPreferencePageTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/arquillian/ui/preferences/ArquillianPreferencePageTest.java
@@ -1,0 +1,94 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.eclipse.test.arquillian.ui.preferences;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.reddeer.eclipse.arquillian.ui.preferences.ArquillianPreferencePage;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for class that represents Arquillian preference page
+ * 
+ * @author Vlado Pakan, Len DiMaggio
+ *
+ */
+@RunWith(RedDeerSuite.class)
+public class ArquillianPreferencePageTest {
+
+	private WorkbenchPreferenceDialog preferencesDialog = new WorkbenchPreferenceDialog();
+	private ArquillianPreferencePage arquillianPreferencePage = new ArquillianPreferencePage();
+	private final String VERSION_STRING = "1.1.10.Final";
+	private final String ARG_STRING = "TEST ARGS";
+
+	@Test
+	public void checkAllPreferences() {
+		preferencesDialog.open();
+		preferencesDialog.select(arquillianPreferencePage);
+		
+		arquillianPreferencePage.setDefaultVMArg(true);
+		arquillianPreferencePage.setArquillianVersion (VERSION_STRING);
+		arquillianPreferencePage.setVMArgsText (ARG_STRING);
+		arquillianPreferencePage.setDefaultVMArgsToJUnit(true);
+		arquillianPreferencePage.setDefaultVMArgsToLaunch(true);
+		arquillianPreferencePage.setAllowOSCommandWhenAnalyzing(true);
+		arquillianPreferencePage.setAllowSystemPropWhenAnalyzing(true);
+		
+		assertTrue(arquillianPreferencePage.isDefaultVMArgChecked());
+		assertTrue(arquillianPreferencePage.getArquillianVersion().equals(VERSION_STRING));
+		assertTrue(arquillianPreferencePage.getVMArgsText().equals(ARG_STRING));
+		assertTrue(arquillianPreferencePage.isAddDefaultVMArgsToJUnitChecked());
+		assertTrue(arquillianPreferencePage.isAddDefaultVMArgsToLaunchChecked());
+		assertTrue(arquillianPreferencePage.isAllowOSCommandWhenAnalyzingChecked());
+		assertTrue(arquillianPreferencePage.isAllowSystemPropWhenAnalyzingChecked());
+		
+		preferencesDialog.cancel();
+	}
+
+	@Test
+	public void uncheckAllPreferences() {
+		preferencesDialog.open();
+		preferencesDialog.select(arquillianPreferencePage);
+		
+		/* setDefaultVMArgsToJUnit and setDefaultVMArgsToLaunch are dependent on setDefaultVMArgChecked */
+		arquillianPreferencePage.setDefaultVMArg(true);		
+		arquillianPreferencePage.setDefaultVMArgsToJUnit(false);
+		arquillianPreferencePage.setDefaultVMArgsToLaunch(false);
+		assertFalse(arquillianPreferencePage.isAddDefaultVMArgsToJUnitChecked());
+		assertFalse(arquillianPreferencePage.isAddDefaultVMArgsToLaunchChecked());
+				
+		arquillianPreferencePage.setDefaultVMArg(false);
+		arquillianPreferencePage.setAllowOSCommandWhenAnalyzing(false);
+		arquillianPreferencePage.setAllowSystemPropWhenAnalyzing(false);
+
+		assertFalse(arquillianPreferencePage.isDefaultVMArgChecked());
+		assertFalse(arquillianPreferencePage.isAllowOSCommandWhenAnalyzingChecked());
+		assertFalse(arquillianPreferencePage.isAllowSystemPropWhenAnalyzingChecked());
+		
+		preferencesDialog.cancel();
+	}	
+		
+	@After
+	public void tearDown(){
+		// try to close preference dialog in case it stayed open
+		try{
+			preferencesDialog.cancel();
+		} catch (SWTLayerException swtle){
+			// do nothing
+		}
+	}
+}

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/arquillian/ui/preferences/ArquillianValidatorPreferencePageTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/arquillian/ui/preferences/ArquillianValidatorPreferencePageTest.java
@@ -1,0 +1,99 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.eclipse.test.arquillian.ui.preferences;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.reddeer.eclipse.arquillian.ui.preferences.ArquillianValidatorPreferencePage;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.workbench.ui.dialogs.WorkbenchPreferenceDialog;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for class that represents Arquillian preference page
+ * 
+ * @author Vlado Pakan, Len DiMaggio
+ *
+ */
+@RunWith(RedDeerSuite.class)
+public class ArquillianValidatorPreferencePageTest {
+
+	private WorkbenchPreferenceDialog preferencesDialog = new WorkbenchPreferenceDialog();
+	private ArquillianValidatorPreferencePage arquillianValidatorPreferencePage = new ArquillianValidatorPreferencePage();
+	private final String ERROR = "Error";
+	private final String WARNING = "Warning";
+	private final String IGNORE = "Ignore";
+	private final String SEVERITY_FILTER_STRING = "test filter string";
+
+	@Test
+	public void checkAllPreferences() {
+		preferencesDialog.open();
+		preferencesDialog.select(arquillianValidatorPreferencePage);
+		
+		arquillianValidatorPreferencePage.setEnableValidation(true);
+		arquillianValidatorPreferencePage.setTestArquillianContainer(true);
+		
+		/* Note: Default setting is WARNING, change it here for the test */
+		arquillianValidatorPreferencePage.setDeploymentMethod(ERROR);
+		arquillianValidatorPreferencePage.setMissingTestMethod(ERROR);
+		arquillianValidatorPreferencePage.setTypeNotIncluded(ERROR);
+		arquillianValidatorPreferencePage.setImportNotIncluded(ERROR);
+		arquillianValidatorPreferencePage.setDeployArchiveNotIncluded(ERROR);
+		arquillianValidatorPreferencePage.setInvalidArchiveName(ERROR);
+		arquillianValidatorPreferencePage.setDeployMethodPublicStatic(ERROR);
+		arquillianValidatorPreferencePage.setInvalidArchiveFileLocation(ERROR);
+
+		assertTrue(arquillianValidatorPreferencePage.isTestEnableValidationChecked());
+		assertTrue(arquillianValidatorPreferencePage.isTestArquillianContainerChecked());
+		
+		assertTrue(arquillianValidatorPreferencePage.getDeploymentMethod().equals(ERROR));
+		assertTrue(arquillianValidatorPreferencePage.getMissingTestMethod().equals(ERROR));
+		assertTrue(arquillianValidatorPreferencePage.getTypeNotIncluded().equals(ERROR));
+		assertTrue(arquillianValidatorPreferencePage.getImportNotIncluded().equals(ERROR));
+		assertTrue(arquillianValidatorPreferencePage.getDeployArchiveNotIncluded().equals(ERROR));
+		assertTrue(arquillianValidatorPreferencePage.getInvalidArchiveName().equals(ERROR));
+		assertTrue(arquillianValidatorPreferencePage.getDeployMethodPublicStatic().equals(ERROR));
+		assertTrue(arquillianValidatorPreferencePage.getInvalidArchiveFileLocation().equals(ERROR));
+				
+		arquillianValidatorPreferencePage.setSelectedSeverity(SEVERITY_FILTER_STRING);
+		assertTrue(arquillianValidatorPreferencePage.getSelectedSeverity().equals(SEVERITY_FILTER_STRING));
+		
+		preferencesDialog.cancel();
+	}
+
+	@Test
+	public void uncheckAllPreferences() {
+		preferencesDialog.open();
+		preferencesDialog.select(arquillianValidatorPreferencePage);
+		
+		arquillianValidatorPreferencePage.setEnableValidation(false);
+		arquillianValidatorPreferencePage.setTestArquillianContainer(false);
+
+		assertFalse(arquillianValidatorPreferencePage.isTestEnableValidationChecked());
+		assertFalse(arquillianValidatorPreferencePage.isTestArquillianContainerChecked());
+		
+		preferencesDialog.cancel();
+	}	
+		
+	@After
+	public void tearDown(){
+		// try to close preference dialog in case it stayed open
+		try{
+			preferencesDialog.cancel();
+		} catch (SWTLayerException swtle){
+			// do nothing
+		}
+	}
+}


### PR DESCRIPTION
Add classes to support for Arquillian and Arquillian Validator pages to Red Deer 

These classes will support the creating of automated tests for the Arquillian and Arquillian Validator pages.

