### PR TITLE
apodhrad_ProblemsView getProblems might fail due to disposed widget

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/problems/ProblemsView.java
@@ -11,7 +11,6 @@
 package org.jboss.reddeer.eclipse.ui.problems;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -19,6 +18,7 @@ import org.jboss.reddeer.common.wait.TimePeriod;
 import org.jboss.reddeer.common.wait.WaitUntil;
 import org.jboss.reddeer.common.wait.WaitWhile;
 import org.jboss.reddeer.core.condition.ShellWithTextIsAvailable;
+import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.eclipse.condition.AbstractExtendedMarkersViewIsUpdating;
 import org.jboss.reddeer.eclipse.exception.EclipseLayerException;
 import org.jboss.reddeer.eclipse.ui.problems.matcher.AbstractProblemMatcher;
@@ -64,13 +64,20 @@ public class ProblemsView extends WorkbenchView{
 	 */
 	private List<TreeItem> filterProblemType(List<TreeItem> list, ProblemType problemType){
 		for (TreeItem problemSeverityTreeItem : list) {
-			if (problemSeverityTreeItem.getText().matches("^Errors \\(\\d+ item.*\\)") 
-					&& problemType == ProblemType.ERROR) {
-				return problemSeverityTreeItem.getItems();
-			} 
-			if (problemSeverityTreeItem.getText().matches("^Warnings \\(\\d+ item.*\\)")
-					&& problemType == ProblemType.WARNING) {
-				return problemSeverityTreeItem.getItems();
+			try{
+				if (problemSeverityTreeItem.getText().matches("^Errors \\(\\d+ item.*\\)") 
+						&& problemType == ProblemType.ERROR) {
+					return problemSeverityTreeItem.getItems();
+				} 
+				if (problemSeverityTreeItem.getText().matches("^Warnings \\(\\d+ item.*\\)")
+						&& problemType == ProblemType.WARNING) {
+					return problemSeverityTreeItem.getItems();
+				}
+			} catch (CoreLayerException ex){
+				//if widget is disposed we can ignore it - problem disappeared
+				if(!problemSeverityTreeItem.isDisposed()){
+					throw ex;
+				}
 			}
 		}
 		return new LinkedList<TreeItem>();
@@ -101,9 +108,16 @@ public class ProblemsView extends WorkbenchView{
 			boolean itemFitsMatchers = true;
 			if(matchers != null){
 				for (AbstractProblemMatcher matcher: matchers) {
-					if (!matcher.matches(item.getCell(getIndexOfColumn(matcher.getColumn())))) {
-						itemFitsMatchers = false;
-						break;
+					try{
+						if (!matcher.matches(item.getCell(getIndexOfColumn(matcher.getColumn())))) {
+							itemFitsMatchers = false;
+							break;
+						}
+					} catch (CoreLayerException ex){
+						//if widget is disposed we can ignore it - problem disappeared
+						if(!item.isDisposed()){
+							throw ex;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
org.jboss.reddeer.core.exception.CoreLayerException: Exception during sync execution in UI thread
	at org.jboss.reddeer.core.util.Display.syncExec(Display.java:87)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethodUI(ObjectUtil.java:60)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:41)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:23)
	at org.jboss.reddeer.core.handler.WidgetHandler.getText(WidgetHandler.java:167)
	at org.jboss.reddeer.core.handler.TreeItemHandler.expand(TreeItemHandler.java:376)
	at org.jboss.reddeer.core.handler.TreeItemHandler.getChildrenItems(TreeItemHandler.java:220)
	at org.jboss.reddeer.swt.impl.tree.AbstractTreeItem.getItems(AbstractTreeItem.java:212)
	at org.jboss.reddeer.eclipse.ui.problems.ProblemsView.filterProblemType(ProblemsView.java:52)
	at org.jboss.reddeer.eclipse.ui.problems.ProblemsView.filterSpecificProblems(ProblemsView.java:82)
	at org.jboss.reddeer.eclipse.ui.problems.ProblemsView.filterProblems(ProblemsView.java:68)
	at org.jboss.reddeer.eclipse.ui.problems.ProblemsView.getProblems(ProblemsView.java:42)
	at org.jboss.tools.cdi.reddeer.uiutils.ValidationHelper.findProblems(ValidationHelper.java:60)
	at org.jboss.tools.cdi.bot.test.beans.stereotype.template.StereotypeValidationQuickFixTemplate.testRetentionAnnotation(StereotypeValidationQuickFixTemplate.java:100)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.jboss.reddeer.junit.internal.runner.statement.RunTestMethod.evaluate(RunTestMethod.java:36)
	at org.jboss.reddeer.junit.internal.runner.statement.RunBefores.evaluate(RunBefores.java:69)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIBeforeTestExtensions.evaluate(RunIBeforeTestExtensions.java:63)
	at org.jboss.reddeer.junit.internal.runner.statement.RunAfters.evaluate(RunAfters.java:58)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIAfterTestExtensions.evaluate(RunIAfterTestExtensions.java:51)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.runChild(RequirementsRunner.java:165)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.jboss.reddeer.junit.internal.runner.statement.RunBefores.evaluate(RunBefores.java:69)
	at org.jboss.reddeer.junit.internal.runner.statement.FulfillRequirementsStatement.evaluate(FulfillRequirementsStatement.java:35)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIBeforeClassExtensions.evaluate(RunIBeforeClassExtensions.java:60)
	at org.jboss.reddeer.junit.internal.runner.statement.RunAfters.evaluate(RunAfters.java:58)
	at org.jboss.reddeer.junit.internal.runner.statement.CleanUpRequirementStatement.evaluate(CleanUpRequirementStatement.java:34)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIAfterClassExtensions.evaluate(RunIAfterClassExtensions.java:48)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:146)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:91)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.jboss.reddeer.core.exception.CoreLayerException: Exception when invoking method public java.lang.String org.eclipse.swt.widgets.TreeItem.getText() by reflection
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:72)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:68)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:63)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:160)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4155)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3772)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
Caused by: java.lang.reflect.InvocationTargetException: null
	at sun.reflect.GeneratedMethodAccessor61.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:70)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:68)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:63)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:160)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4155)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3772)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
Caused by: org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4491)
	at org.eclipse.swt.SWT.error(SWT.java:4406)
	at org.eclipse.swt.SWT.error(SWT.java:4377)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:482)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:354)
	at org.eclipse.swt.widgets.TreeItem.getText(TreeItem.java:880)
	at sun.reflect.GeneratedMethodAccessor61.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.jboss.reddeer.core.util.ObjectUtil.invokeMethod(ObjectUtil.java:70)
	at org.jboss.reddeer.core.util.ObjectUtil.access$0(ObjectUtil.java:68)
	at org.jboss.reddeer.core.util.ObjectUtil$1.run(ObjectUtil.java:63)
	at org.jboss.reddeer.core.util.Display$ErrorHandlingRunnable.run(Display.java:160)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:135)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4155)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3772)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1127)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1018)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:156)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:654)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:337)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:598)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:150)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:139)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:380)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:235)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:669)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:608)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1515)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1488)
