### PR TITLE
Provide reasonable toString() in LogMessage.

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogMessage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/log/LogMessage.java
@@ -120,4 +120,12 @@ public class LogMessage {
 		return lm;
 	}
 
+	@Override
+	public String toString() {
+		return "LogMessage [getSeverity()=" + getSeverity() + ", getMessage()=" + getMessage() + ", getPlugin()="
+				+ getPlugin() + ", getDate()=" + getDate() + ", getStackTrace()=" + getStackTrace()
+				+ ", getSessionData()=" + getSessionData() + ", getSubLogMessages()=" + getSubLogMessages() + "]";
+	}
+	
+	
 }


### PR DESCRIPTION
This enables for example `logger.error(logView.getErrorMessages())` with reasonable output.