### PR TITLE
Logic improvement in WithStyleMatcher

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/matcher/WithStyleMatcher.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/matcher/WithStyleMatcher.java
@@ -45,7 +45,7 @@ public class WithStyleMatcher extends BaseMatcher<Integer> {
 		if (item instanceof Widget){
 			try {
 				Integer widgetStyle = WidgetHandler.getInstance().getStyle((Widget)item);
-				return (widgetStyle.intValue() & style) != 0;
+				return (widgetStyle.intValue() & style) == style;
 			} catch (CoreLayerException sle) {
 				// object is not supported by widget handler mechanism 'getStyle'
 				return false;


### PR DESCRIPTION
Widget has a specified style if it has all its bits.
In binary logic A has (contains) B if A & B = B.
Examples:
1. Any widget matches style SWT.NONE. It seems strange, but alternative would be
   that any widget, even with style SWT.NONE does not match SWT.NONE.
2. Table matches style SWT.BORDER | SWT_V_SCROLL only if its style has
   both SWT.BORDER _and_ SWT.V_SCROLL. Previous version would match
   if table had at least one of these bits. That might be a way to
   match styles but only with unambiguous description like
   "has at least one bit of style" instead of "has style".

Current usages of WithStyleMatcher that I have found are limited to one-bit styles
for which expressions A & B = B and A & B != 0 are equivalent, but I think
it might be fixed for correctly matching multi-bit styles.