### PR TITLE
Performance improvement of WidgetLookup.activeWidget

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/condition/WidgetIsFound.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/condition/WidgetIsFound.java
@@ -84,7 +84,7 @@ public class WidgetIsFound <T extends Widget> extends AbstractWaitCondition {
 	 */
 	public boolean test() {
 		
-		properWidget = widgetLookup.getProperWidget(widgetLookup.activeWidgets(parent, am), index);
+		properWidget = widgetLookup.activeWidget(parent, am, index);
 
 		if(properWidget == null){
 			return false;


### PR DESCRIPTION
This method is used by AbstractWidget and therefore by all reddeer widgets,
which are created in most integration tests. So, it is one of methods
performance of which is critical.

Previous implementation collected the entire list of matching SWT widgets,
iterating over all widgets in referenced composite and then picked up
an element by the given index. Very often reference composite is not set
so that iteration goes over all widgets of the window.

The suggested implementation does the same iteration but without creating lists
and interrupting the iteration as soon as the requested number of matches is found
(and in most usages the first match is requested).

Otherwise, the logic of the search does not changed. Tests of Reddeer pass.