### PR TITLE
Method WidgetResolver.getParent(Widget) is fixed

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/resolver/WidgetResolver.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/resolver/WidgetResolver.java
@@ -14,8 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.xml.soap.Text;
-
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.widgets.Composite;
@@ -80,12 +78,9 @@ public class WidgetResolver  {
 		TabItem.class,
 		ToolBar.class,
 		Composite.class,
-		Control.class,
-		Text.class
+		Control.class
 	};
 	
-	private TabItem[] items;
-
 	/**
 	 * Returns parent of specified widget. If widget is not resolvable, return null.
 	 * Must be called from UI Thread.
@@ -94,7 +89,6 @@ public class WidgetResolver  {
 	 * @return parent widget or null
 	 */
 	public Widget getParent(Widget w) {
-		if (isResolvable(w)) {
 			if (w instanceof ExpandBar) {
 				return ((ExpandBar) w).getParent();
 			}
@@ -116,31 +110,36 @@ public class WidgetResolver  {
 			else if (w instanceof ToolBar) {
 				return ((ToolBar) w).getParent();
 			}
+			else if (w instanceof ToolItem) {
+				return ((ToolItem) w).getParent();
+			}
+			else if (w instanceof TableItem) {
+				return ((TableItem) w).getParent();
+			}
 			else if (w instanceof Composite) {
-				// Control
-				Composite parent = w instanceof Control ? ((Control) w).getParent() : null;
+				Composite parent = ((Composite)w).getParent();
 				
 				// If composite under TabFolder find widget under TabFolder siblings
-				if ((w instanceof Composite) && (parent instanceof TabFolder)) {
+				if (parent instanceof TabFolder) {
 						
 					if ((parent == null) || parent.isDisposed()) {
 						throw new CoreLayerException("TabFolder is null or disposed while resolving");
 					}
 					TabItem[] tabItems = ((TabFolder) parent).getItems();
 
-					int index = -1;
-					index = Arrays.asList(tabItems).indexOf(w);
+					int index = Arrays.asList(tabItems).indexOf(w);
 					
-					if (index == -1) throw new CoreLayerException("Widget not found under TabFolder");
+					if (index == -1) {
+						throw new CoreLayerException("Widget not found under TabFolder");
+					}
 					
-					return items[index];
+					return tabItems[index];
 				}
 				return parent;
 			}
 			else if (w instanceof Control) {
 				return ((Control) w).getParent();
 			}
-		}
 		log.warn("Cannot find parent of widget. Widget type is not supported (" + w.getClass() + ")");
 		return null;
 	}

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/WidgetResolverTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/WidgetResolverTest.java
@@ -1,0 +1,105 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.swt.test;
+
+import java.util.List;
+
+import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Widget;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.core.lookup.WidgetLookup;
+import org.jboss.reddeer.core.resolver.WidgetResolver;
+import org.jboss.reddeer.core.util.Display;
+import org.jboss.reddeer.core.util.ResultRunnable;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(RedDeerSuite.class)
+public class WidgetResolverTest {
+	private Logger log = Logger.getLogger(WidgetResolverTest.class);
+
+	/**
+	 * For each widget found in active window check that for each 
+	 * child widget returned by WidgetResolver.getInstance().getChildren(widget) 
+	 * the parent returned by WidgetResolver.getInstance().getParent(childWidget) 
+	 * is equal to the widget with the exception of CTabItem when the parent 
+	 * returned for its control is CTabFolder which is the parent to both of them.
+	 */
+	@Test
+	public void parentMatchesChildrenTest() {
+		Shell shell = new DefaultShell().getSWTWidget();
+		List<Widget> all = WidgetLookup.getInstance().activeWidgets(shell, new BaseMatcher<Widget>() {
+			@Override
+			public boolean matches(Object obj) {
+				return true;
+			}
+
+			@Override
+			public void describeTo(Description desc) {				
+			}
+			
+		});
+		log.info("Testing " + all.size() + " widgets for matching children to parent.");
+
+		Assert.assertFalse("Shell is empty, test cannot be done.", all.isEmpty());
+
+		for (Widget c: all) {
+			List<Widget> children = getChildrenSync(c);
+			Widget p = getParentSync(c);
+			for (Widget w: children) {
+				Widget parent = getParentSync(w);
+						
+				Assert.assertNotNull("Widget " + syncToString(w) + " was returned as a child of control " + syncToString(c) + " but WidgetResolver.getInstance().getParent() returned null.", parent);
+				if(c instanceof CTabItem) {
+					//Now implementation should return its 'natural' parent CTabFolder.
+					Assert.assertEquals("For child " + syncToString(w) + " of CTabItem was return wrong parent.", p, parent);
+				} else {
+					Assert.assertEquals("For child " + syncToString(w) + " was returned wrong parent " + syncToString(parent), c, parent);
+				}
+				log.info("Child widget " + syncToString(w) + " matches to its parent widget " + syncToString(c));
+			}
+		} 
+	}
+
+	List<Widget> getChildrenSync(final Widget widget) {
+		return Display.syncExec(new ResultRunnable<List<Widget>>() {
+			@Override
+			public List<Widget> run() {
+				return WidgetResolver.getInstance().getChildren(widget);			
+			}
+		});
+	}
+
+	Widget getParentSync(final Widget widget) {
+		return Display.syncExec(new ResultRunnable<Widget>() {
+			@Override
+			public Widget run() {
+				return WidgetResolver.getInstance().getParent(widget);			
+			}
+		});
+	}
+
+	String syncToString(final Widget widget) {
+		return Display.syncExec(new ResultRunnable<String>() {
+			@Override
+			public String run() {
+				return widget.toString();			
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
This method should match method getChildren(Widget).
Together they should allow to navigate the tree of widgets
in a consistent way.
Test is added.