### PR TITLE
Support publishing Red Deer to JBoss Nexus

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -67,8 +67,8 @@
 			<uniqueVersion>false</uniqueVersion>
 		</snapshotRepository>
 		<repository>
-			<id>jboss-releases-repository</id>
-			<name>JBoss Releases Repository</name>
+			<id>jboss-staging-repository</id>
+			<name>JBoss Staging Service</name>
 			<uniqueVersion>false</uniqueVersion>
 			<url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</url>
 		</repository>


### PR DESCRIPTION
To support publishing to JBoss Nexus, you need a distributionManagement section with paths to the snapshot repo:

https://github.com/jbosstools/jbosstools-build/blob/master/parent/pom.xml#L977-L992