### PR TITLE
Improve exception message in ComboHandler

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/CComboHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/CComboHandler.java
@@ -113,7 +113,8 @@ public class CComboHandler {
 						log.info("    " + item + "(index " + i);
 						i++;
 					}
-					throw new CoreLayerException("Nonexisting item in custom combo was requested");
+					throw new CoreLayerException("Nonexisting item in custom combo with text \"" 
+												+ text + "\" was requested");
 				} else {
 					ccombo.select(index);
 				}

--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/ComboHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/ComboHandler.java
@@ -112,7 +112,7 @@ public class ComboHandler {
 						i++;
 					}
 					throw new CoreLayerException(
-							"Nonexisting item in combo was requested");
+							"Nonexisting item in combo with text \"" + text + "\" was requested");
 				} else {
 					combo.select(index);
 				}


### PR DESCRIPTION
The method setSelection(final Combo combo, final String text) throws only "Nonexisted item in combo was requested". Extend this message by the requested combo text.