### PR TITLE
Screenshots are not created for requirements

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/Requirements.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/Requirements.java
@@ -80,7 +80,7 @@ public class Requirements implements Requirement<Annotation>, Iterable<Requireme
 				boolean canFulfillReq = r.canFulfill();
 				log.info("Requirement " + r.getClass() + " can be fulfilled: " + canFulfillReq);
 				canFulfill = canFulfill && canFulfillReq;
-			} catch (RuntimeException ex) {
+			} catch (Throwable ex) {
 				ScreenshotCapturer screenshotCapturer = ScreenshotCapturer.getInstance();
 				try {
 					screenshotCapturer.captureScreenshotOnFailure(configID, 
@@ -103,7 +103,7 @@ public class Requirements implements Requirement<Annotation>, Iterable<Requireme
 			try {
 				log.info("Fulfilling requirement of " + r.getClass());
 				r.fulfill();
-			} catch (RuntimeException ex) {
+			} catch (Throwable ex) {
 				ScreenshotCapturer screenshotCapturer = ScreenshotCapturer.getInstance();
 				try {
 					screenshotCapturer.captureScreenshotOnFailure(configID, 
@@ -133,7 +133,7 @@ public class Requirements implements Requirement<Annotation>, Iterable<Requireme
 			try {
 				log.info("Cleaning up requirement of " + r.getClass());
 				r.cleanUp();
-			} catch (RuntimeException ex) {
+			} catch (Throwable ex) {
 				ScreenshotCapturer screenshotCapturer = ScreenshotCapturer.getInstance();
 				try {
 					screenshotCapturer.captureScreenshotOnFailure(configID, 


### PR DESCRIPTION
If requirement throw subclass of RuntimeError, screenshot is done. Otherwise not, what causing issues when throwing e.g. AssertionError