### PR TITLE
Update RedDeer version to 1.0.3-SNAPSHOT

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -4,7 +4,7 @@
 	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.jboss.reddeer</groupId>
-	<version>1.0.2.Final</version>
+	<version>1.0.3-SNAPSHOT</version>
 	<artifactId>jboss-reddeer-archetype</artifactId>
 	<packaging>maven-archetype</packaging>
 	<name>Red Deer Archetype</name>

--- a/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -7,7 +7,7 @@
       <defaultValue>mars</defaultValue>
     </requiredProperty>
     <requiredProperty key="reddeer_version">
-      <defaultValue>1.0.2</defaultValue>
+      <defaultValue>1.0.3</defaultValue>
     </requiredProperty>
     <requiredProperty key="version">
        <defaultValue>1.0.0-SNAPSHOT</defaultValue>

--- a/features/org.jboss.reddeer.eclipse.feature/feature.xml
+++ b/features/org.jboss.reddeer.eclipse.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.eclipse.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.eclipse.feature/pom.xml
+++ b/features/org.jboss.reddeer.eclipse.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.examples.feature/feature.xml
+++ b/features/org.jboss.reddeer.examples.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.examples.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.examples.feature/pom.xml
+++ b/features/org.jboss.reddeer.examples.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.gef.spy.feature/feature.xml
+++ b/features/org.jboss.reddeer.gef.spy.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.gef.spy.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.gef.spy.feature/pom.xml
+++ b/features/org.jboss.reddeer.gef.spy.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.graphiti.feature/feature.xml
+++ b/features/org.jboss.reddeer.graphiti.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.graphiti.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.graphiti.feature/pom.xml
+++ b/features/org.jboss.reddeer.graphiti.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.help.feature/feature.xml
+++ b/features/org.jboss.reddeer.help.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.help.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.help.feature/pom.xml
+++ b/features/org.jboss.reddeer.help.feature/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<name>Red Deer Help Feature</name>

--- a/features/org.jboss.reddeer.ide.feature/feature.xml
+++ b/features/org.jboss.reddeer.ide.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.ide.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.ide.feature/pom.xml
+++ b/features/org.jboss.reddeer.ide.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.junit.extension.feature/feature.xml
+++ b/features/org.jboss.reddeer.junit.extension.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.junit.extension.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.junit.extension.feature/pom.xml
+++ b/features/org.jboss.reddeer.junit.extension.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.logparser.feature/feature.xml
+++ b/features/org.jboss.reddeer.logparser.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.logparser.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
     <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.logparser.feature/pom.xml
+++ b/features/org.jboss.reddeer.logparser.feature/pom.xml
@@ -9,7 +9,7 @@
   	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/features/org.jboss.reddeer.rcp.feature/feature.xml
+++ b/features/org.jboss.reddeer.rcp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.rcp.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.rcp.feature/pom.xml
+++ b/features/org.jboss.reddeer.rcp.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.recorder.feature/feature.xml
+++ b/features/org.jboss.reddeer.recorder.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.recorder.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.recorder.feature/pom.xml
+++ b/features/org.jboss.reddeer.recorder.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.selenium.feature/feature.xml
+++ b/features/org.jboss.reddeer.selenium.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.selenium.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
     <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.selenium.feature/pom.xml
+++ b/features/org.jboss.reddeer.selenium.feature/pom.xml
@@ -9,7 +9,7 @@
   	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/features/org.jboss.reddeer.spy.feature/feature.xml
+++ b/features/org.jboss.reddeer.spy.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.spy.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
     <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.spy.feature/pom.xml
+++ b/features/org.jboss.reddeer.spy.feature/pom.xml
@@ -9,7 +9,7 @@
   	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<build>

--- a/features/org.jboss.reddeer.swt.feature/feature.xml
+++ b/features/org.jboss.reddeer.swt.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.swt.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.swt.feature/pom.xml
+++ b/features/org.jboss.reddeer.swt.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.tests.feature/feature.xml
+++ b/features/org.jboss.reddeer.tests.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.tests.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.tests.feature/pom.xml
+++ b/features/org.jboss.reddeer.tests.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/org.jboss.reddeer.ui.feature/feature.xml
+++ b/features/org.jboss.reddeer.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.jboss.reddeer.ui.feature"
       label="%featureName"
-      version="1.0.2.Final"
+      version="1.0.3.qualifier"
       provider-name="JBoss by Red Hat">
 
    <description url="https://github.com/jboss-reddeer/reddeer/wiki">

--- a/features/org.jboss.reddeer.ui.feature/pom.xml
+++ b/features/org.jboss.reddeer.ui.feature/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>features</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -5,7 +5,7 @@
         <parent>
                 <groupId>org.jboss.reddeer</groupId>
                 <artifactId>parent</artifactId>
-                <version>1.0.2.Final</version>
+                <version>1.0.3-SNAPSHOT</version>
         </parent>
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>features</artifactId>

--- a/plugins/org.jboss.reddeer.branding/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.branding/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Branding Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.branding;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Eclipse-BundleShape: dir

--- a/plugins/org.jboss.reddeer.branding/pom.xml
+++ b/plugins/org.jboss.reddeer.branding/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.common/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.common/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Common
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.common
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.common.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.common/pom.xml
+++ b/plugins/org.jboss.reddeer.common/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.core/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Core
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.core
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.core.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.core/pom.xml
+++ b/plugins/org.jboss.reddeer.core/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Direct
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.direct
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.direct.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.direct/pom.xml
+++ b/plugins/org.jboss.reddeer.direct/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Eclipse Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.eclipse/pom.xml
+++ b/plugins/org.jboss.reddeer.eclipse/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.examples/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Examples
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.examples
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Require-Bundle: org.jboss.reddeer.eclipse;bundle-version="[1.0,1.1)",
  org.jboss.reddeer.jface;bundle-version="[1.0,1.1)",
  org.jboss.reddeer.junit;bundle-version="[1.0,1.1)",

--- a/plugins/org.jboss.reddeer.examples/pom.xml
+++ b/plugins/org.jboss.reddeer.examples/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.gef.spy/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.gef.spy/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer GEF Spy
 Bundle-SymbolicName: org.jboss.reddeer.gef.spy;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.spy.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.gef.spy/pom.xml
+++ b/plugins/org.jboss.reddeer.gef.spy/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
         <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/plugins/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.gef/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer GEF Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.gef
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.gef/pom.xml
+++ b/plugins/org.jboss.reddeer.gef/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.generator/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.generator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Code Generator
 Bundle-SymbolicName: org.jboss.reddeer.generator;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.generator.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.generator/pom.xml
+++ b/plugins/org.jboss.reddeer.generator/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.go/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.go/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Go
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.go
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.ui;visibility:=reexport,

--- a/plugins/org.jboss.reddeer.go/pom.xml
+++ b/plugins/org.jboss.reddeer.go/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.graphiti/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.graphiti/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Graphiti Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.graphiti
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.graphiti.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.graphiti/pom.xml
+++ b/plugins/org.jboss.reddeer.graphiti/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.help/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.help/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Help Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.help;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.help.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.reddeer.help/pom.xml
+++ b/plugins/org.jboss.reddeer.help/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.jboss.reddeer.help</artifactId>

--- a/plugins/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.jface/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JFace Componnet
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.jface/pom.xml
+++ b/plugins/org.jboss.reddeer.jface/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Extensions
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.junit.extension;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.extension.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.junit.extension/pom.xml
+++ b/plugins/org.jboss.reddeer.junit.extension/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	
 </project>

--- a/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Support
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.junit;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.junit/pom.xml
+++ b/plugins/org.jboss.reddeer.junit/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/plugins/org.jboss.reddeer.logparser/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.logparser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Log Parser
 Bundle-SymbolicName: org.jboss.reddeer.logparser;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.logparser.LogParserActivator
 Bundle-Vendor: Red Hat
 Require-Bundle: org.eclipse.ui,

--- a/plugins/org.jboss.reddeer.logparser/pom.xml
+++ b/plugins/org.jboss.reddeer.logparser/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.jboss.reddeer.logparser</artifactId>

--- a/plugins/org.jboss.reddeer.recorder/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.recorder/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.jboss.reddeer.recorder Core Plugin
 Bundle-SymbolicName: org.jboss.reddeer.recorder;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.recorder.core.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.recorder/pom.xml
+++ b/plugins/org.jboss.reddeer.recorder/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
         <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
   <artifactId>org.jboss.reddeer.recorder</artifactId>

--- a/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.requirements/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Reddeer Requirements support
 Bundle-SymbolicName: org.jboss.reddeer.requirements
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.requirements/pom.xml
+++ b/plugins/org.jboss.reddeer.requirements/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/plugins/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Selenium Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.selenium
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.redderr.bot.selenium.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/plugins/org.jboss.reddeer.selenium/pom.xml
+++ b/plugins/org.jboss.reddeer.selenium/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.spy/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Spy
 Bundle-SymbolicName: org.jboss.reddeer.spy;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.spy.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.swt,

--- a/plugins/org.jboss.reddeer.spy/pom.xml
+++ b/plugins/org.jboss.reddeer.spy/pom.xml
@@ -4,7 +4,7 @@
  	<parent>
  		<groupId>org.jboss.reddeer</groupId>
  		<artifactId>plugins</artifactId>
- 		<version>1.0.2.Final</version>
+ 		<version>1.0.3-SNAPSHOT</version>
  	</parent>
  	
 	<modelVersion>4.0.0</modelVersion>

--- a/plugins/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.swt/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.Activator
 Require-Bundle: org.hamcrest.core;bundle-version="1.3.0",
  org.eclipse.swt,

--- a/plugins/org.jboss.reddeer.swt/pom.xml
+++ b/plugins/org.jboss.reddeer.swt/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer UI Component
 Bundle-SymbolicName: org.jboss.reddeer.ui;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.ui.Activator
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/plugins/org.jboss.reddeer.ui/pom.xml
+++ b/plugins/org.jboss.reddeer.ui/pom.xml
@@ -7,7 +7,7 @@
   <parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
   </parent>
   
 </project>

--- a/plugins/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Red Deer UI Forms Components
 Bundle-SymbolicName: org.jboss.reddeer.uiforms
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.uiforms.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.uiforms/pom.xml
+++ b/plugins/org.jboss.reddeer.uiforms/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.workbench/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Workbench Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.jboss.reddeer.workbench/pom.xml
+++ b/plugins/org.jboss.reddeer.workbench/pom.xml
@@ -9,6 +9,6 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
                 <artifactId>plugins</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -5,7 +5,7 @@
         <parent>
                 <groupId>org.jboss.reddeer</groupId>
                 <artifactId>parent</artifactId>
-                <version>1.0.2.Final</version>
+                <version>1.0.3-SNAPSHOT</version>
         </parent>
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>parent</artifactId>
 	<name>Red Deer Parent POM File</name>
-	<version>1.0.2.Final</version>
+	<version>1.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<properties>

--- a/product/org.jboss.reddeer.product
+++ b/product/org.jboss.reddeer.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="JBoss Red Deer" uid="reddeer-100" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="1.0.2.Final" useFeatures="true" includeLaunchers="true">
+<product name="JBoss Red Deer" uid="reddeer-100" id="org.eclipse.platform.ide" application="org.eclipse.ui.ide.workbench" version="1.0.3.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <text>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/snippets/META-INF/MANIFEST.MF
+++ b/snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Red Deer Snippets
 Bundle-SymbolicName: snippets
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/snippets/pom.xml
+++ b/snippets/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/tests/org.jboss.reddeer.common.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.common.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Common Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.common.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.common.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)"
 Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.reddeer.common.test/pom.xml
+++ b/tests/org.jboss.reddeer.common.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 </project>

--- a/tests/org.jboss.reddeer.core.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.core.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Core Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.core.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.core.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)"
 Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.reddeer.core.test/pom.xml
+++ b/tests/org.jboss.reddeer.core.test/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.direct.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.direct.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Direct Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.direct.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.direct.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)"
 Bundle-ActivationPolicy: lazy

--- a/tests/org.jboss.reddeer.direct.test/pom.xml
+++ b/tests/org.jboss.reddeer.direct.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.eclipse.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Eclipse Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.eclipse.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.eclipse.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.jboss.reddeer.gef;bundle-version="[1.0,1.1)",

--- a/tests/org.jboss.reddeer.eclipse.test/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/tests/org.jboss.reddeer.gef.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.gef.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer GEF Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.gef.test
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.gef.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.jboss.reddeer.gef;bundle-version="[1.0,1.1)"

--- a/tests/org.jboss.reddeer.gef.test/pom.xml
+++ b/tests/org.jboss.reddeer.gef.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.generator.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.generator.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Code Generator Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.generator.test
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.generator.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.jboss.reddeer.generator;bundle-version="[1.0,1.1)"

--- a/tests/org.jboss.reddeer.generator.test/pom.xml
+++ b/tests/org.jboss.reddeer.generator.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.graphiti.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.graphiti.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Graphiti Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.graphiti.test
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.graphiti.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.jboss.reddeer.gef;bundle-version="[1.0,1.1)",

--- a/tests/org.jboss.reddeer.graphiti.test/pom.xml
+++ b/tests/org.jboss.reddeer.graphiti.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.jface.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JFace Componnet Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.jface.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.jface.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.jboss.reddeer.swt.test;bundle-version="[1.0,1.1)"

--- a/tests/org.jboss.reddeer.jface.test/pom.xml
+++ b/tests/org.jboss.reddeer.jface.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.junit.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.junit.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer JUnit Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.junit.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.junit.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.hamcrest.library;bundle-version="1.3.0",

--- a/tests/org.jboss.reddeer.junit.test/pom.xml
+++ b/tests/org.jboss.reddeer.junit.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<build>

--- a/tests/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.requirements.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Requirements Test
 Bundle-SymbolicName: org.jboss.reddeer.requirements.test
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.requirements.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/tests/org.jboss.reddeer.requirements.test/pom.xml
+++ b/tests/org.jboss.reddeer.requirements.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	
 	<properties>

--- a/tests/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.swt.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer SWT Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.swt.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.swt.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.eclipse.core.expressions,

--- a/tests/org.jboss.reddeer.swt.test/pom.xml
+++ b/tests/org.jboss.reddeer.swt.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.uiforms.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Red Deer UI Forms Components Test
 Bundle-SymbolicName: org.jboss.reddeer.uiforms.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.uiforms.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.eclipse.ui.views.log,

--- a/tests/org.jboss.reddeer.uiforms.test/pom.xml
+++ b/tests/org.jboss.reddeer.uiforms.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.reddeer.workbench.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: RedDeer Workbench Component Tests
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.workbench.test;singleton:=true
-Bundle-Version: 1.0.2.Final
+Bundle-Version: 1.0.3.qualifier
 Bundle-Activator: org.jboss.reddeer.workbench.test.Activator
 Require-Bundle: org.jboss.reddeer.go;bundle-version="[1.0,1.1)",
  org.eclipse.jface.text,

--- a/tests/org.jboss.reddeer.workbench.test/pom.xml
+++ b/tests/org.jboss.reddeer.workbench.test/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.0.2.Final</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<profiles>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
         <parent>
                 <groupId>org.jboss.reddeer</groupId>
                 <artifactId>parent</artifactId>
-                <version>1.0.2.Final</version>
+                <version>1.0.3-SNAPSHOT</version>
         </parent>
 	<groupId>org.jboss.reddeer</groupId>
 	<artifactId>tests</artifactId>


### PR DESCRIPTION
Command used for upversioning:
mvn org.eclipse.tycho:tycho-versions-plugin:set-version -DnewVersion=1.0.3-SNAPSHOT

In addition, these files were modified manually:
archetype/pom.xml
archetype/src/main/resources/META-INF/maven/archetype-metadata.xml

Ranges were not updated because they are set to [1.0,1.1) which is still correct.