### PR TITLE
org.jboss.reddeer.eclipse.test.jst.j2ee.ui.project.facet.EARProjectWizardTest.createProjectWithDefaultModules failed

### DIFF
--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jst/j2ee/ui/project/facet/EARProjectWizardTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/jst/j2ee/ui/project/facet/EARProjectWizardTest.java
@@ -21,11 +21,9 @@ import org.jboss.reddeer.eclipse.jst.j2ee.wizard.NewJ2EEComponentSelectionPage;
 import org.jboss.reddeer.eclipse.jst.servlet.ui.WebProjectFirstPage;
 import org.jboss.reddeer.eclipse.jst.servlet.ui.WebProjectWizard;
 import org.jboss.reddeer.eclipse.ui.perspectives.JavaEEPerspective;
-import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,30 +32,12 @@ import org.junit.runner.RunWith;
 public class EARProjectWizardTest {
 	
 	private String projectName = "EARProject";
-	private ProjectExplorer explorer;
-	private boolean modulesAreCreated;
-	private boolean webModuleIsCreated;
-	
-	@Before
-	public void openProjectExplorer() {
-		explorer = new ProjectExplorer();
-		explorer.open();
-		modulesAreCreated = false;
-		webModuleIsCreated = false;
-	}
 	
 	@After
 	public void deleteProject() {
-		DeleteUtils.forceProjectDeletion(explorer.getProject(projectName), true);
-		if (modulesAreCreated) {
-			DeleteUtils.forceProjectDeletion(explorer.getProject(projectName + "Client"), true);
-			DeleteUtils.forceProjectDeletion(explorer.getProject(projectName + "Connector"), true);
-			DeleteUtils.forceProjectDeletion(explorer.getProject(projectName + "EJB"), true);
-			DeleteUtils.forceProjectDeletion(explorer.getProject(projectName + "Web"), true);
-		}
-		if (webModuleIsCreated) {
-			DeleteUtils.forceProjectDeletion(explorer.getProject("CreatedWebProjectModule"), true);
-		}
+		ProjectExplorer explorer = new ProjectExplorer();
+		explorer.open();
+		explorer.deleteAllProjects();
 	}
 	
 	@Test
@@ -70,7 +50,10 @@ public class EARProjectWizardTest {
 		EarProjectInstallPage ip = new EarProjectInstallPage();
 		assertFalse(ip.isGenerateApplicationXML());
 		ear.finish();
-		assertTrue(explorer.containsProject(projectName));
+		
+		ProjectExplorer pe = new ProjectExplorer();
+		pe.open();
+		assertTrue(pe.containsProject(projectName));
 	}
 	
 	@Test
@@ -89,12 +72,14 @@ public class EARProjectWizardTest {
 		String appClient = jee.getApplicationClientModuleName();
 		jee.finish();
 		ear.finish();
+		
+		ProjectExplorer explorer = new ProjectExplorer();
+		explorer.open();
 		assertTrue(explorer.containsProject(projectName));
 		assertTrue(explorer.containsProject(ejb));
 		assertTrue(explorer.containsProject(conn));
 		assertTrue(explorer.containsProject(web));
 		assertTrue(explorer.containsProject(appClient));
-		modulesAreCreated = true;
 	}
 	
 	@Test
@@ -113,8 +98,11 @@ public class EARProjectWizardTest {
 		wp.setProjectName("CreatedWebProjectModule");
 		ww.finish();
 		ear.finish();
+		
+		ProjectExplorer explorer = new ProjectExplorer();
+		explorer.open();
+		
 		assertTrue(explorer.containsProject(projectName));
-		webModuleIsCreated = true;
 		assertTrue(explorer.containsProject("CreatedWebProjectModule"));
 	}
 


### PR DESCRIPTION
http://machydra.brq.redhat.com:8080/job/RedDeer_verification_matrix/jdk=sunjdk1.7,label=stable-linux/2220/testReport/junit/org.jboss.reddeer.eclipse.test.jst.j2ee.ui.project.facet/EARProjectWizardTest/createProjectWithDefaultModules_default/?

Error Message

No control has focus. Perhaps something has stolen it? Try to regain focus with for example "new DefaultShell()".
Stacktrace

org.jboss.reddeer.core.exception.CoreLayerException: No control has focus. Perhaps something has stolen it? Try to regain focus with for example "new DefaultShell()".
	at org.jboss.reddeer.core.lookup.MenuLookup.getTopMenuMenuItemsFromFocus(MenuLookup.java:187)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:43)
	at org.jboss.reddeer.swt.impl.menu.ContextMenu.<init>(ContextMenu.java:33)
	at org.jboss.reddeer.eclipse.core.resources.AbstractProject.delete(AbstractProject.java:76)
	at org.jboss.reddeer.eclipse.utils.DeleteUtils.forceProjectDeletion(DeleteUtils.java:72)
	at org.jboss.reddeer.eclipse.test.jst.j2ee.ui.project.facet.EARProjectWizardTest.deleteProject(EARProjectWizardTest.java:46)
