### PR TITLE
Add a logic for importing existing maven projects

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/wizard/MavenImportWizard.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/wizard/MavenImportWizard.java
@@ -1,0 +1,147 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.eclipse.m2e.core.ui.wizard;
+
+import org.jboss.reddeer.common.matcher.RegexMatcher;
+import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitUntil;
+import org.jboss.reddeer.common.wait.WaitWhile;
+import org.jboss.reddeer.core.condition.JobIsRunning;
+import org.jboss.reddeer.core.exception.CoreLayerException;
+import org.jboss.reddeer.core.matcher.WithTextMatcher;
+import org.jboss.reddeer.jface.wizard.ImportWizardDialog;
+import org.jboss.reddeer.swt.api.Shell;
+import org.jboss.reddeer.swt.condition.ShellIsAvailable;
+import org.jboss.reddeer.swt.exception.SWTLayerException;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+
+/**
+ * Wizard for importing an existing maven project.
+ * 
+ * @author apodhrad
+ *
+ */
+public class MavenImportWizard extends ImportWizardDialog {
+
+	public static final String TITLE = "Import Maven Projects";
+
+	private MavenImportWizardPage page;
+
+	/**
+	 * Constructs ImportWizard with "Maven > Existing Maven Projects".
+	 */
+	public MavenImportWizard() {
+		super("Maven", "Existing Maven Projects");
+		page = new MavenImportWizardPage();
+	}
+
+	public MavenImportWizardPage getWizardPage() {
+		return page;
+	}
+
+	@Override
+	public void finish() {
+		finish(TimePeriod.VERY_LONG);
+	}
+
+	@Override
+	public void finish(TimePeriod timeout) {
+		Shell shell = new DefaultShell(TITLE);
+		new PushButton("Finish").click();
+		new WaitWhile(new ShellIsAvailable(shell), TimePeriod.NORMAL);
+
+		// check whether there some addition dialog
+		try {
+			ResolveDialog dialog = new ResolveDialog();
+			dialog.resolveAllLater();
+			dialog.finish();
+		} catch (Exception e) {
+			// ok, it means that the warning wasn't displayed
+		}
+		// check whether there some addition dialog
+		try {
+			IncompleteDialog dialog = new IncompleteDialog();
+			dialog.ok();
+		} catch (CoreLayerException | SWTLayerException e) {
+			// ok, it means that the warning wasn't displayed
+		}
+
+		new WaitUntil(new JobIsRunning(), TimePeriod.NORMAL, false);
+		new WaitWhile(new JobIsRunning(), timeout);
+	}
+
+	/**
+	 * Imports the whole project.
+	 * 
+	 * @param path
+	 *            Path
+	 */
+	public static void importProject(String path) {
+		importProject(path, TimePeriod.VERY_LONG);
+	}
+
+	/**
+	 * Imports the whole project.
+	 * 
+	 * @param path
+	 *            Path
+	 * @param timeout
+	 *            Timeout
+	 */
+	public static void importProject(String path, TimePeriod timeout) {
+		MavenImportWizard wizard = new MavenImportWizard();
+		wizard.open();
+		wizard.getWizardPage().setRootDirectory(path);
+		wizard.getWizardPage().refresh();
+		wizard.getWizardPage().waitUntilProjectIsLoaded(TimePeriod.VERY_LONG);
+		wizard.finish(timeout);
+	}
+
+	/**
+	 * Additional dialog which occurs only during importing a maven project.
+	 */
+	private class ResolveDialog extends DefaultShell {
+
+		public static final String TITLE_MARS = "Import Maven Projects";
+		public static final String TITLE_NEON = "Discover m2e connectors";
+
+		public ResolveDialog() {
+			super(new WithTextMatcher(new RegexMatcher("(" + TITLE_MARS + ")|(" + TITLE_NEON + ")")));
+		}
+
+		public void resolveAllLater() {
+			new PushButton("Resolve All Later").click();
+		}
+
+		public void finish() {
+			new PushButton("Finish").click();
+			new WaitWhile(new ShellIsAvailable(this));
+		}
+
+	}
+
+	/**
+	 * Additional dialog which occurs only during importing a maven project.
+	 */
+	private class IncompleteDialog extends DefaultShell {
+
+		public IncompleteDialog() {
+			super("Incomplete Maven Goal Execution");
+		}
+
+		public void ok() {
+			new PushButton("OK").click();
+			new WaitWhile(new ShellIsAvailable(this));
+		}
+
+	}
+}

--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/wizard/MavenImportWizardPage.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/m2e/core/ui/wizard/MavenImportWizardPage.java
@@ -1,0 +1,94 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.eclipse.m2e.core.ui.wizard;
+
+import org.jboss.reddeer.common.condition.AbstractWaitCondition;
+import org.jboss.reddeer.common.wait.TimePeriod;
+import org.jboss.reddeer.common.wait.WaitUntil;
+import org.jboss.reddeer.jface.wizard.WizardPage;
+import org.jboss.reddeer.swt.impl.button.PushButton;
+import org.jboss.reddeer.swt.impl.combo.LabeledCombo;
+import org.jboss.reddeer.swt.impl.shell.DefaultShell;
+
+/**
+ * Wizard page used in MavenImportWizard.
+ * 
+ * @author apodhrad
+ *
+ */
+public class MavenImportWizardPage extends WizardPage {
+
+	public static final String TITLE = "Import Maven Projects";
+
+	/**
+	 * Default constructor.
+	 */
+	public MavenImportWizardPage() {
+
+	}
+
+	/**
+	 * Activates the wizard.
+	 */
+	public void activate() {
+		new DefaultShell(TITLE);
+	}
+
+	/**
+	 * Sets a root directory.
+	 * 
+	 * @param path
+	 *            Path
+	 */
+	public void setRootDirectory(String path) {
+		activate();
+		new LabeledCombo("Root Directory:").setText(path);
+	}
+
+	/**
+	 * Clicks on 'Refresh' button.
+	 */
+	public void refresh() {
+		activate();
+		new PushButton("Refresh").click();
+	}
+
+	/**
+	 * Waits until a project is loaded (usually after refresh).
+	 * 
+	 * @param timeout
+	 *            Timeout
+	 */
+	public void waitUntilProjectIsLoaded(TimePeriod timeout) {
+		activate();
+		new WaitUntil(new ProjectsIsLoaded(), timeout);
+	}
+
+	/**
+	 * WaitCondition which determines whether a project was successfully reloaded (usually after refresh).
+	 * 
+	 * @author apodhrad
+	 *
+	 */
+	private class ProjectsIsLoaded extends AbstractWaitCondition {
+
+		@Override
+		public boolean test() {
+			return new PushButton("Finish").isEnabled() || new PushButton("Next >").isEnabled();
+		}
+
+		@Override
+		public String description() {
+			return "The project is still not loaded.";
+		}
+
+	}
+}

--- a/tests/org.jboss.reddeer.eclipse.test/resources/org/jboss/reddeer/eclipse/test/m2e/core/ui/wizard/maven-test-project/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/resources/org/jboss/reddeer/eclipse/test/m2e/core/ui/wizard/maven-test-project/pom.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.example</groupId>
+	<artifactId>maven-test-project</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+</project>

--- a/tests/org.jboss.reddeer.eclipse.test/resources/org/jboss/reddeer/eclipse/test/m2e/core/ui/wizard/maven-wrong-project/pom.xml
+++ b/tests/org.jboss.reddeer.eclipse.test/resources/org/jboss/reddeer/eclipse/test/m2e/core/ui/wizard/maven-wrong-project/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.example</groupId>
+	<artifactId>maven-wrong-project</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.4.0</version>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>cleanVersions</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>cleanVersions</goal>
+						</goals>
+						<configuration>
+							<versions>
+								<foo.version>${foo.version}</foo.version>
+							</versions>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/m2e/core/ui/wizard/MavenImportWizardTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/m2e/core/ui/wizard/MavenImportWizardTest.java
@@ -1,0 +1,66 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.eclipse.test.m2e.core.ui.wizard;
+
+import static org.jboss.reddeer.eclipse.m2e.core.ui.wizard.MavenImportWizard.importProject;
+
+import java.io.File;
+import java.util.List;
+
+import org.jboss.reddeer.eclipse.core.resources.Project;
+import org.jboss.reddeer.eclipse.jdt.ui.ProjectExplorer;
+import org.jboss.reddeer.eclipse.test.Activator;
+import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * 
+ * @author apodhrad
+ *
+ */
+@RunWith(RedDeerSuite.class)
+public class MavenImportWizardTest {
+
+	@Test
+	public void testImportingMavenProject() {
+		String projectName = "maven-test-project";
+
+		importProject(getPath(projectName));
+		assertProject(projectName);
+	}
+
+	@Test
+	public void testImportingWrongMavenProject() {
+		String projectName = "maven-wrong-project";
+
+		importProject(getPath(projectName));
+		assertProject(projectName);
+	}
+
+	private String getPath(String projectName) {
+		File file = new File(Activator.getTestResourcesLocation(MavenImportWizardTest.class), projectName);
+		return file.getAbsolutePath();
+	}
+
+	private void assertProject(String projectName) {
+		ProjectExplorer pe = new ProjectExplorer();
+		pe.open();
+		List<Project> projects = pe.getProjects();
+		for (Project project : projects) {
+			if (project.getName().equals(projectName)) {
+				return;
+			}
+		}
+		Assert.fail("Project '" + projectName + "' wasn't created properly");
+	}
+}


### PR DESCRIPTION
- import an existing maven project
- take care of some pop ups
- wait until the project is built
- check Error Log (with optional exceptions such as "Plugin is not covered ...")