### PR TITLE
rev_Add logic for collecting .log output

### DIFF
--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/properties/RedDeerProperties.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/properties/RedDeerProperties.java
@@ -34,6 +34,8 @@ public enum RedDeerProperties {
 	CLOSE_ALL_SHELLS("rd.closeShells", true),
 
 	DISABLE_MAVEN_REPOSITORY_DOWNLOAD("rd.disableMavenIndex", true),
+	
+	LOG_COLLECTOR_ENABLED("rd.logCollectorEnabled", true),
 
 	/**
 	 * System property pointing either to the configuration file or to the configuration directory. 

--- a/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.direct/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.jboss.reddeer.direct.preferences,
- org.jboss.reddeer.direct.project
+ org.jboss.reddeer.direct.project,
+ org.jboss.reddeer.direct.platform

--- a/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/platform/Platform.java
+++ b/plugins/org.jboss.reddeer.direct/src/org/jboss/reddeer/direct/platform/Platform.java
@@ -1,0 +1,31 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.direct.platform;
+
+import java.io.File;
+
+/**
+ * This class provides support for Eclipse Platform.
+ * 
+ * @author mlabuda@redhat.com
+ * @since 1.2.0
+ */
+public class Platform {
+
+	/**
+	 * Gets Eclipse workbench log file located at workspace .metadata directory.
+	 * 
+	 * @return eclipse log file
+	 */
+	public static File getWorkbenchLog() {
+		return org.eclipse.core.runtime.Platform.getLogFileLocation().toFile();
+	}
+}

--- a/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.junit.extension/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.reddeer.common;bundle-version="[1.2,1.3)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
-Import-Package: org.jboss.reddeer.junit.screenshot
+Import-Package: org.jboss.reddeer.direct.platform,
+ org.jboss.reddeer.junit.screenshot
 Export-Package: org.jboss.reddeer.junit.extension.issue.tracker.impl
  

--- a/plugins/org.jboss.reddeer.junit.extension/plugin.xml
+++ b/plugins/org.jboss.reddeer.junit.extension/plugin.xml
@@ -12,11 +12,17 @@
       <client
             class="org.jboss.reddeer.junit.extension.before.test.impl.SetOpenAssociatedPerspectiveExt">
       </client>
+      <client
+      		class="org.jboss.reddeer.junit.extension.log.collector.BeforesLogCollector">
+      </client>
    </extension>
    <extension
          point="org.jboss.reddeer.junit.after.test">
       <client
             class="org.jboss.reddeer.junit.extension.after.test.impl.CloseAllShellsExt">
+      </client>
+      <client
+      		class="org.jboss.reddeer.junit.extension.log.collector.AftersLogCollector">
       </client>
    </extension>
    <extension

--- a/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/ExtensionPriority.java
+++ b/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/ExtensionPriority.java
@@ -22,7 +22,9 @@ public class ExtensionPriority {
 	public static final long CLOSE_WELCOME_SCREEN_PRIORITY = 1000000;
 	public static final long SET_OPEN_ASSOCIATED_PERSPECTIVE_PRIORITY = 10000;
 	public static final long DO_NOT_DOWNLOAD_MAVEN_INDICES_PRIORITY = 1000;
+	public static final long BEFORES_LOG_COLLECTOR_PRIORITY = Long.MAX_VALUE;
 	
 	// After extensions priorities
 	public static final long CLOSE_ALL_SHELLS_PRIORITY = -1000000;
+	public static final long AFTERSLOG_COLLECTOR_PRIORITY = Long.MIN_VALUE;
 }

--- a/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/log/collector/AftersLogCollector.java
+++ b/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/log/collector/AftersLogCollector.java
@@ -1,0 +1,66 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.junit.extension.log.collector;
+
+import org.jboss.reddeer.common.properties.RedDeerProperties;
+import org.jboss.reddeer.direct.platform.Platform;
+import org.jboss.reddeer.junit.extension.ExtensionPriority;
+import org.jboss.reddeer.junit.extensionpoint.IAfterTest;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+/**
+ * Afters log collector provides collecting workbench log at two points. First one is 
+ * after execution of AfterTest extensions. Second point is after execution of AfterClass
+ * extensions.
+ * 
+ * @author mlabuda@redhat.com
+ * @since 1.2.0
+ *
+ */
+public class AftersLogCollector extends LogCollector implements IAfterTest {
+
+	public static String AFTER_TEST_METHOD_DESCRIPTION = 
+			"Log entries collected between before extensions (included) and\n"
+			+ "after extensions (included) for test method:"; 
+	
+	public static final String AFTER_TEST_CLASS_DESCRIPTION = 
+			"Log entries collected between after extensions (excluded) \n"
+			+ "and after class extensions (included):"; 
+	
+	@Override
+	public long getPriority() {
+		return ExtensionPriority.AFTERSLOG_COLLECTOR_PRIORITY;
+	}
+
+	@Override
+	public void runAfterTestClass(String config, TestClass testClass) {
+		processWorkbenchLog(config, testClass.getJavaClass().getSimpleName(), AFTER_TEST_CLASS_DESCRIPTION);
+		Platform.getWorkbenchLog().delete();
+	}
+
+	@Override
+	public void runAfterTest(String config, Object target, FrameworkMethod method) {
+		constructAfterTestMethodDescription(method.getMethod().getName());
+		processWorkbenchLog(config, method.getDeclaringClass().getSimpleName(), AFTER_TEST_METHOD_DESCRIPTION);
+		Platform.getWorkbenchLog().delete();
+	}
+
+	@Override
+	public boolean hasToRun() {
+		return RedDeerProperties.LOG_COLLECTOR_ENABLED.getBooleanValue();
+	}
+
+	private void constructAfterTestMethodDescription(String testMethodName) {
+		AFTER_TEST_METHOD_DESCRIPTION =  "Log entries collected between before extensions (included) and\n"
+				+ "after extensions (included) for test method " + testMethodName + ":";  
+	}
+}

--- a/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/log/collector/BeforesLogCollector.java
+++ b/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/log/collector/BeforesLogCollector.java
@@ -1,0 +1,58 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.junit.extension.log.collector;
+
+import org.jboss.reddeer.common.properties.RedDeerProperties;
+import org.jboss.reddeer.direct.platform.Platform;
+import org.jboss.reddeer.junit.extension.ExtensionPriority;
+import org.jboss.reddeer.junit.extensionpoint.IBeforeTest;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+/**
+ * Befores log collector provides collecting workbench log at two points. First one is 
+ * before execution of any BeforeClass extension. Second point is before execution of any
+ * BeforeTest extension.
+ *  
+ * @author mlabuda@redhat.com
+ * @since 1.2.0
+ */
+public class BeforesLogCollector extends LogCollector implements IBeforeTest{
+	
+	public static final String BEFORE_TEST_METHOD_DESCRIPTION = 
+			"Log entries collected between before class extensions (included)\n"
+			+ "and before extensions (excluded) for a test method:";
+	
+	public static boolean hasToRun = true;
+	
+	@Override
+	public long getPriority() {
+		return ExtensionPriority.BEFORES_LOG_COLLECTOR_PRIORITY;
+	}
+
+	@Override
+	public void runBeforeTestClass(String config, TestClass testClass) {	
+		Platform.getWorkbenchLog().delete();
+		hasToRun = true;
+	}
+
+	@Override
+	public void runBeforeTest(String config, Object target, FrameworkMethod method) {
+		processWorkbenchLog(config, method.getDeclaringClass().getSimpleName(), BEFORE_TEST_METHOD_DESCRIPTION);
+		Platform.getWorkbenchLog().delete();
+		hasToRun = false;
+	}
+
+	@Override
+	public boolean hasToRun() {
+		return RedDeerProperties.LOG_COLLECTOR_ENABLED.getBooleanValue() && hasToRun;
+	}
+}

--- a/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/log/collector/LogCollector.java
+++ b/plugins/org.jboss.reddeer.junit.extension/src/org/jboss/reddeer/junit/extension/log/collector/LogCollector.java
@@ -1,0 +1,131 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.junit.extension.log.collector;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.jboss.reddeer.direct.platform.Platform;
+
+
+/**
+ * Log collector collect Eclipse workbench log and process it for a specific test class and test methods.
+ * This is useful for post test run evaluation whether there were any silent errors/warnings shown in log.
+ * 
+ * @author mlabuda@redhat.com
+ * @since 1.2.0
+ */
+public class LogCollector {
+
+	private static final long timestamp = System.currentTimeMillis();
+	
+	/**
+	 * Gets file name for a file with collected log entries. File name
+	 * contains config name and time stamp.
+	 * 
+	 * @param config
+	 *            RedDeer config
+	 * @param className  test class name
+	 * @return file name of log file
+	 */
+	public String getFileName(String config, String className) {
+		return "config-" + config + "_class-" + className + "_" + getID();
+	}
+
+	/**
+	 * Gets log file ID in form of date in format yyyy-MM-dd_HH-mm-ss.
+	 * 
+	 * @return id of log file in 
+	 */
+	private String getID() {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+		return dateFormat.format(new Date(timestamp)).toString();
+	}
+	
+	/**
+	 * Gets location of directory where file with collected log entries
+	 * is/supposed to be saved. Directory is set by default to target/reddeer-log.
+	 * 
+	 * @return path to log directory
+	 */
+	public String getDirectory() {
+		return System.getProperty("user.dir") + File.separator + "target" + File.separator +
+				"reddeer-log" + File.separator;
+	}
+
+	/**
+	 * Gets path to RedDeer log file. Path consists of log directory and log file name. See 
+	 * {@link #getDirectory()} and {@link #getFileName(String)}.
+	 * 
+	 * @param config RedDeer config
+	 * @param className test class name
+	 * @return path to RedDeer log file
+	 */
+	public String getLogFilePath(String config, String className) {
+		return getDirectory() + File.separator + getFileName(config, className);
+	}
+	
+	/**
+	 * Gets RedDeer log file for specified config. If file does not exists, it is created at first.
+	 * @param config RedDeer config
+	 * @param className test class name
+	 * @return log file
+	 */
+	public File getLogFile(String config, String className) {
+		File logFile = new File(getLogFilePath(config, className));
+		// First call, if file does not exists
+		if (!logFile.exists()) {
+			logFile.getParentFile().mkdirs();
+			try {
+				logFile.createNewFile();
+			} catch (IOException e) {
+				// Should not happen
+				e.printStackTrace();
+			}
+		}
+		return logFile;
+	}
+	
+	/**
+	 * Processes workbench log. It copies log entries from Eclipse workbench log to RedDeer log file of 
+	 * a specific test class.
+	 * 
+	 * @param config RedDeer config 
+	 * @param class test class name
+	 * @param logDescription description related to log entries
+	 */
+	public  void processWorkbenchLog(String config, String className, String logDescription) {
+		try (BufferedReader br = new BufferedReader(new FileReader(Platform.getWorkbenchLog()));
+				BufferedWriter bw = new BufferedWriter(new FileWriter(getLogFile(config, className), true))) {
+			String line = br.readLine();
+			if (line != null) {
+				bw.write(logDescription + "\n\n");
+				bw.write(line + "\n");
+				while ((line = br.readLine()) != null) {
+					bw.write(line + "\n");
+				}
+				bw.write("\n\n");
+			}
+		} catch (FileNotFoundException e) {
+			// Should not happen
+			e.printStackTrace();
+		} catch (IOException e1) {
+			e1.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
- at the beginning of each test clear log
- after test execution collect logs
- store logs in a file
- log processing should be done via Eclipse API, not via UI