### PR TITLE
MouseDoubleClick event is missing count 

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/handler/WidgetHandler.java
@@ -438,6 +438,9 @@ public class WidgetHandler {
 		event.button = button;
 		event.x = x;
 		event.y = y;
+		if(eventType == SWT.MouseDoubleClick){
+			event.count=2;
+		}
 		return event;
 	}
 	


### PR DESCRIPTION
Count property for this event is important because org.eclipse.jface.viewers.ColumnViewerEditorActivationEvent does some logic around it