### PR TITLE
Allow to work with dirty views

### DIFF
--- a/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/view/AbstractView.java
+++ b/plugins/org.jboss.reddeer.workbench/src/org/jboss/reddeer/workbench/impl/view/AbstractView.java
@@ -67,7 +67,7 @@ public class AbstractView implements View {
 	 *            of view to initialize
 	 */
 	public AbstractView(String viewToolTip) {
-		this(new WithTextMatcher(viewToolTip));
+		this(new WithTextMatcher(new RegexMatcher("\\*?" + viewToolTip)));
 	}
 
 	/**
@@ -120,7 +120,7 @@ public class AbstractView implements View {
 	 */
 	@Override
 	public void activate() {
-		log.info("Activate view " + viewTitle());
+		log.info("Activate view " + getTitle());
 		cTabItemIsNotNull();
 		getViewCTabItem().activate();
 		ViewHandler.getInstance().focusChildControl();
@@ -139,7 +139,7 @@ public class AbstractView implements View {
 			if (!isOpened()){
 				return cTabItem;
 			}
-			log.debug("Looking up CTabItem with text " + viewTitle());
+			log.debug("Looking up CTabItem with text " + getTitle());
 			cTabItem = new DefaultCTabItem(new WorkbenchShell(), viewNameMatcher);
 		}
 		return cTabItem; 
@@ -189,10 +189,6 @@ public class AbstractView implements View {
 		return path;
 	}
 
-	private String viewTitle() {
-		return path[path.length - 1];
-	}
-
 	/* (non-Javadoc)
 	 * @see org.jboss.reddeer.workbench.api.WorkbenchPart#close()
 	 */
@@ -209,10 +205,10 @@ public class AbstractView implements View {
 	 */
 	@Override
 	public void open() {
-		log.info("Open view " + viewTitle());
+		log.info("Open view " + getTitle());
 		// view is not opened, it has to be opened via menu
 		if (getViewCTabItem() == null){
-			log.info("Open " + viewTitle() + " view via menu.");
+			log.info("Open " + getTitle() + " view via menu.");
 			openViaMenu();
 		}
 		activate();
@@ -237,8 +233,7 @@ public class AbstractView implements View {
 		@Override
 		public boolean test() {
 			try {
-				getViewCTabItem();
-				return true;
+				return getViewCTabItem() != null;
 			} catch (Exception e){
 				return false;
 			}
@@ -266,7 +261,7 @@ public class AbstractView implements View {
 	 * @return Title of the view
 	 */
 	public String getTitle() {
-		return viewTitle();
+		return path[path.length - 1];
 	}
 
 	/* (non-Javadoc)
@@ -285,7 +280,7 @@ public class AbstractView implements View {
 		List<org.eclipse.swt.custom.CTabItem> tabs = WidgetLookup.getInstance().activeWidgets(new WorkbenchShell(), org.eclipse.swt.custom.CTabItem.class);
 		for (org.eclipse.swt.custom.CTabItem tab : tabs){
 			String text = WidgetHandler.getInstance().getText(tab);
-			if (viewTitle().equals(text)){
+			if (viewNameMatcher.matches(text)){
 				return true;
 			}
 		}

--- a/tests/org.jboss.reddeer.workbench.test/plugin.xml
+++ b/tests/org.jboss.reddeer.workbench.test/plugin.xml
@@ -10,6 +10,10 @@
         	name="Workbench Test"
         	category="org.jboss.reddeer.workbench.test.ui.category"
         	class="org.jboss.reddeer.workbench.test.ui.views.LabelView" />
+    	<view id="org.jboss.reddeer.workbench.test.ui.views.dirtylabelview"
+        	name="Workbench Dirty Test"
+        	category="org.jboss.reddeer.workbench.test.ui.category"
+        	class="org.jboss.reddeer.workbench.test.ui.views.DirtyLabelView" />
 	</extension>
 	<extension
          point="org.eclipse.ui.editors">

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/ui/views/DirtyLabelView.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/ui/views/DirtyLabelView.java
@@ -1,0 +1,109 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.jboss.reddeer.workbench.test.ui.views;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.ISaveablePart;
+import org.eclipse.ui.part.ViewPart;
+
+/**
+ * A saveable view which contains one labeled text field. Once you edit the text field, the view is set as dirty and
+ * after saving it is set as non-dirty. The view is opened as non-dirty by default. This behavior can be changed by
+ * setting the system property {@link DirtyLabelView#DEFAULT_DIRTY_PROPERTY}.
+ * 
+ * @author Andrej Podhradsky (apodhrad@redhat.com)
+ *
+ */
+public class DirtyLabelView extends ViewPart implements ISaveablePart {
+
+	public static final String DEFAULT_DIRTY_PROPERTY = "rd.viewTest.isDirty";
+	public static final boolean DEFAULT_DIRTY_VALUE = false;
+
+	private static String lastSavedText = "";
+
+	private Label label;
+	private Text text;
+	private boolean isDirty;
+
+	public DirtyLabelView() {
+		super();
+		setDirty(getDefaultDirtyValue());
+	}
+
+	public void setFocus() {
+		label.setFocus();
+	}
+
+	public void createPartControl(Composite parent) {
+		GridLayout gridLayout = new GridLayout(2, true);
+		gridLayout.verticalSpacing = 8;
+
+		Composite composite = new Composite(parent, SWT.NONE);
+		composite.setLayout(gridLayout);
+
+		label = new Label(composite, SWT.NONE);
+		label.setText("Test field: ");
+		text = new Text(composite, SWT.SINGLE | SWT.BORDER);
+		text.setText(lastSavedText);
+		text.addModifyListener(new ModifyListener() {
+
+			@Override
+			public void modifyText(ModifyEvent event) {
+				if (!lastSavedText.equals(text.getText())) {
+					setDirty(true);
+				}
+			}
+		});
+	}
+
+	public void setDirty(boolean isDirty) {
+		this.isDirty = isDirty;
+		firePropertyChange(PROP_DIRTY);
+	}
+
+	@Override
+	public void doSave(IProgressMonitor monitor) {
+		lastSavedText = text.getText();
+		setDirty(false);
+	}
+
+	@Override
+	public void doSaveAs() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isDirty() {
+		return isDirty;
+	}
+
+	@Override
+	public boolean isSaveAsAllowed() {
+		return false;
+	}
+
+	@Override
+	public boolean isSaveOnCloseNeeded() {
+		return false;
+	}
+
+	private boolean getDefaultDirtyValue() {
+		return Boolean.valueOf(System.getProperty(DEFAULT_DIRTY_PROPERTY, String.valueOf(DEFAULT_DIRTY_VALUE)));
+	}
+
+}

--- a/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/view/ViewTest.java
+++ b/tests/org.jboss.reddeer.workbench.test/src/org/jboss/reddeer/workbench/test/view/ViewTest.java
@@ -7,13 +7,17 @@
  * 
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
- ******************************************************************************/ 
+ ******************************************************************************/
 package org.jboss.reddeer.workbench.test.view;
 
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.swt.impl.menu.ShellMenu;
+import org.jboss.reddeer.swt.impl.text.LabeledText;
 import org.jboss.reddeer.workbench.api.View;
 import org.jboss.reddeer.workbench.exception.WorkbenchLayerException;
 import org.jboss.reddeer.workbench.impl.view.WorkbenchView;
+import org.jboss.reddeer.workbench.test.ui.views.DirtyLabelView;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -25,7 +29,7 @@ public class ViewTest {
 		new WorkbenchView("Workbench Test");
 	}
 
-	@Test(expected=WorkbenchLayerException.class)
+	@Test(expected = WorkbenchLayerException.class)
 	public void testInitializeNonregisteredView() {
 		new WorkbenchView("Nonexist View");
 	}
@@ -65,13 +69,13 @@ public class ViewTest {
 		markersView.close();
 	}
 
-	@Test(expected=WorkbenchLayerException.class)
+	@Test(expected = WorkbenchLayerException.class)
 	public void testCloseNoninitializedView() {
 		View customView = new WorkbenchView("Workbench Test");
 		customView.close();
 	}
 
-	@Test(expected=WorkbenchLayerException.class)
+	@Test(expected = WorkbenchLayerException.class)
 	public void testActivateNoninitializedView() {
 		View customView = new WorkbenchView("Workbench Test");
 		customView.activate();
@@ -81,7 +85,7 @@ public class ViewTest {
 	public void testActivateNonFocusedView() {
 		View customView = new WorkbenchView("Workbench Test");
 		customView.open();
-		
+
 		View markersView = new WorkbenchView("Markers");
 		markersView.open();
 
@@ -100,4 +104,35 @@ public class ViewTest {
 		customView.restore();
 		customView.close();
 	}
+
+	/* Tests with a dirty view */
+	
+	@After
+	public void restoreDefaultDirtyValue() {
+		setDefaultDirtyValue(DirtyLabelView.DEFAULT_DIRTY_VALUE);
+	}
+
+	@Test
+	public void testOpenAndCloseDirtyView() {
+		setDefaultDirtyValue(true);
+		View customView = new WorkbenchView("Workbench Dirty Test");
+		customView.open();
+		customView.close();
+	}
+
+	@Test
+	public void testActivateDirtyAndNonDirtyView() {
+		View customView = new WorkbenchView("Workbench Dirty Test");
+		customView.open();
+		new LabeledText("Test field: ").setText("hello");
+		customView.activate();
+		new ShellMenu("File", "Save").select();
+		customView.activate();
+		customView.close();
+	}
+
+	private void setDefaultDirtyValue(boolean isDirty) {
+		System.setProperty(DirtyLabelView.DEFAULT_DIRTY_PROPERTY, String.valueOf(isDirty));
+	}
+
 }


### PR DESCRIPTION
If a view implements ISaveablePart then it can be dirty (added '*'). Unfortunately, it is not possible to use just the matcher as follows
```
new WithTextMatcher(new RegexMatcher("\\*?" + TITLE)
```