### PR TITLE
Export packages in uiforms plugin

### DIFF
--- a/plugins/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.uiforms/META-INF/MANIFEST.MF
@@ -17,4 +17,6 @@ Export-Package: org.jboss.reddeer.uiforms.api,
  org.jboss.reddeer.uiforms.impl.form,
  org.jboss.reddeer.uiforms.impl.formtext,
  org.jboss.reddeer.uiforms.impl.hyperlink,
- org.jboss.reddeer.uiforms.impl.section
+ org.jboss.reddeer.uiforms.impl.section,
+ org.jboss.reddeer.uiforms.matcher,
+ org.jboss.reddeer.uiforms.handler


### PR DESCRIPTION
org.jboss.reddeer.uiforms.handler and org.jboss.reddeer.uiforms.matcher packages are not exported. We could export it if someone would like to expand something or reuse it for own API...