### PR TITLE
Selenium plugin contains typo in package

### DIFF
--- a/plugins/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.reddeer.selenium/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: RedDeer Selenium Component
 Bundle-Vendor: JBoss by Red Hat
 Bundle-SymbolicName: org.jboss.reddeer.selenium
 Bundle-Version: 2.0.0.qualifier
-Bundle-Activator: org.jboss.redderr.bot.selenium.Activator
+Bundle-Activator: org.jboss.reddeer.bot.selenium.Activator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.jboss.reddeer.selenium/pom.xml
+++ b/plugins/org.jboss.reddeer.selenium/pom.xml
@@ -1,14 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	
+
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>org.jboss.reddeer.selenium</artifactId>
 	<name>Red Deer Selenium Component</name>
 	<packaging>eclipse-plugin</packaging>
-	
+
 	<parent>
 		<groupId>org.jboss.reddeer</groupId>
-                <artifactId>plugins</artifactId>
+		<artifactId>plugins</artifactId>
 		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 </project>

--- a/plugins/org.jboss.reddeer.selenium/src/org/jboss/reddeer/bot/selenium/Activator.java
+++ b/plugins/org.jboss.reddeer.selenium/src/org/jboss/reddeer/bot/selenium/Activator.java
@@ -8,7 +8,7 @@
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/ 
-package org.jboss.redderr.bot.selenium;
+package org.jboss.reddeer.bot.selenium;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;


### PR DESCRIPTION
Selenium plugin (currently empty) has package org.jboss.redderr.bot.selenium. We should fix this typo. It affects also plugin ID in Activator.