### PR TITLE
Add support for nested suites

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/NamedSuite.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/NamedSuite.java
@@ -23,6 +23,7 @@ import org.junit.runners.model.RunnerBuilder;
 public class NamedSuite extends Suite {
 	
 	private final String suiteName;
+	private final RunnerBuilder builder;
 
 	/**
 	 * Constructor used for suites. 
@@ -34,6 +35,7 @@ public class NamedSuite extends Suite {
 	 */
 	public NamedSuite(Class<?> clazz, RunnerBuilder builder, String name) throws InitializationError {
 		super(clazz, builder);
+		this.builder = builder;
 		this.suiteName = name;
 	}
 	
@@ -47,6 +49,7 @@ public class NamedSuite extends Suite {
 	 */
 	public NamedSuite(Class<?>[] classes, RunnerBuilder builder, String name) throws InitializationError {
 		super(builder, EmptySuite.class, classes);
+		this.builder = builder;
 		this.suiteName = name;
 	}
 	
@@ -64,5 +67,13 @@ public class NamedSuite extends Suite {
 	@Override
 	public String toString() {
 		return "Suite '" + suiteName + "'";
+	}
+	
+	/**
+	 * Gets runner builder
+	 * @return runner builder
+	 */
+	public RunnerBuilder getRunnerBuilder(){
+		return builder;
 	}
 }

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
@@ -21,10 +21,15 @@ import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
 import org.jboss.reddeer.junit.internal.requirement.Requirements;
 import org.jboss.reddeer.junit.internal.requirement.RequirementsBuilder;
 import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunListener;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Suite;
+import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
+import org.junit.runners.model.TestClass;
 
 /**
  * Checks if the requirements on the test class can be fulfilled and creates a runner for the test class or
@@ -90,10 +95,13 @@ public class RequirementsRunnerBuilder extends RunnerBuilder {
 	 */
 	@Override
 	public Runner runnerForClass(Class<?> clazz) throws Throwable {
-		log.info("Found test " + clazz);
 		if (clazz.getAnnotation(Ignore.class) != null) {
-			 return new IgnoredClassRunner(clazz);
+			return new IgnoredClassRunner(clazz);
 		}
+		if(clazz.getAnnotation(Suite.SuiteClasses.class) != null){
+			return new Suite(clazz, this);
+		}
+		log.info("Found test " + clazz);
 		if(testsManager != null) {
 			testsManager.addTest(clazz);
 		}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuite.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/runner/RedDeerSuite.java
@@ -7,7 +7,7 @@
  * 
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
- ******************************************************************************/ 
+ ******************************************************************************/
 package org.jboss.reddeer.junit.runner;
 
 import java.util.ArrayList;
@@ -36,7 +36,8 @@ import org.junit.runners.model.RunnerBuilder;
 
 /**
  * 
- * Allows to run the tests (single or a suite) for each configuration file provided.
+ * Allows to run the tests (single or a suite) for each configuration file
+ * provided.
  * 
  * @author Lucia Jelinkova
  * 
@@ -52,40 +53,53 @@ public class RedDeerSuite extends Suite {
 	private static List<IBeforeTest> beforeTestExtensions = RedDeerSuite.initializeBeforeTestExtensions();
 
 	private static List<IAfterTest> afterTestExtensions = RedDeerSuite.initializeAfterTestExtensions();
-	
+
 	private static List<IIssueTracker> issueTrackerExtensions;
+	private String suiteName;
 
 	/**
 	 * Called by the JUnit framework.
 	 *
-	 * @param clazz the clazz
-	 * @param builder the builder
-	 * @throws InitializationError the initialization error
+	 * @param clazz
+	 *            the clazz
+	 * @param builder
+	 *            the builder
+	 * @throws InitializationError
+	 *             the initialization error
 	 */
 	public RedDeerSuite(Class<?> clazz, RunnerBuilder builder) throws InitializationError {
 		this(clazz, builder, new SuiteConfiguration());
 	}
 
 	/**
-	 * The {@link EmptySuite} makes sure that the @BeforeClass and @AfterClass are not called on the suite class too
-	 * often.
+	 * The {@link EmptySuite} makes sure that the @BeforeClass and @AfterClass
+	 * are not called on the suite class too often.
 	 *
-	 * @param clazz the clazz
-	 * @param builder the builder
-	 * @param config the config
-	 * @throws InitializationError the initialization error
+	 * @param clazz
+	 *            the clazz
+	 * @param builder
+	 *            the builder
+	 * @param config
+	 *            the config
+	 * @throws InitializationError
+	 *             the initialization error
 	 */
-	protected RedDeerSuite(Class<?> clazz, RunnerBuilder builder, SuiteConfiguration config) throws InitializationError {
+	protected RedDeerSuite(Class<?> clazz, RunnerBuilder builder, SuiteConfiguration config)
+			throws InitializationError {
 		super(EmptySuite.class, createSuite(clazz, config));
+		this.suiteName = clazz.getName();
 	}
 
 	/**
 	 * Creates a new suite for each configuration file found.
 	 *
-	 * @param clazz the clazz
-	 * @param config the config
+	 * @param clazz
+	 *            the clazz
+	 * @param config
+	 *            the config
 	 * @return the list
-	 * @throws InitializationError the initialization error
+	 * @throws InitializationError
+	 *             the initialization error
 	 */
 	public static List<Runner> createSuite(Class<?> clazz, SuiteConfiguration config) throws InitializationError {
 		log.info("Creating RedDeer suite...");
@@ -94,16 +108,15 @@ public class RedDeerSuite extends Suite {
 		boolean isSuite = isSuite(clazz);
 
 		for (TestRunConfiguration testRunConfig : config.getTestRunConfigurations()) {
-			log.info("Adding suite with name " + testRunConfig.getId() + " to RedDeer suite");
+			log.info("Adding config with name " + testRunConfig.getId() + " to RedDeer suite");
+			RequirementsRunnerBuilder reqRunnerBuilder = new RequirementsRunnerBuilder(testRunConfig, runListeners,
+					beforeTestExtensions, afterTestExtensions, testsManager);
 			if (isSuite) {
-				configuredSuites.add(new NamedSuite(clazz, new RequirementsRunnerBuilder(testRunConfig, runListeners,
-						beforeTestExtensions, afterTestExtensions, testsManager), testRunConfig.getId()));
+				configuredSuites.add(new NamedSuite(clazz, reqRunnerBuilder, testRunConfig.getId()));
 			} else {
-				configuredSuites.add(new NamedSuite(new Class[] { clazz }, new RequirementsRunnerBuilder(testRunConfig,
-						runListeners, beforeTestExtensions, afterTestExtensions, testsManager), testRunConfig.getId()));
+				configuredSuites.add(new NamedSuite(new Class[] { clazz }, reqRunnerBuilder, testRunConfig.getId()));
 			}
 		}
-
 		if (!testsManager.allTestsAreExecuted()) {
 			if (isSuite) {
 				configuredSuites.add(new TestsWithoutExecutionSuite(clazz, testsManager));
@@ -120,12 +133,14 @@ public class RedDeerSuite extends Suite {
 		return annotation != null;
 	}
 
-	/* (non-Javadoc)
+	/*
+	 * (non-Javadoc)
+	 * 
 	 * @see org.junit.runners.ParentRunner#getName()
 	 */
 	@Override
 	protected String getName() {
-		return "Red Deer Suite";
+		return suiteName;
 	}
 
 	/**
@@ -163,7 +178,7 @@ public class RedDeerSuite extends Suite {
 		}
 		return afterTestExts;
 	}
-	
+
 	/**
 	 * Gets a list of issue tracker extensions.
 	 * 
@@ -175,7 +190,7 @@ public class RedDeerSuite extends Suite {
 		}
 		return issueTrackerExtensions;
 	}
-	
+
 	/**
 	 * Initializes all Issue tracker extensions
 	 */


### PR DESCRIPTION
[4:40 PM] Rob Stryker: im running  a suite named AllTestsSuite
[4:41 PM] Rob Stryker: @RunWith(RedDeerSuite.class)
@Suite.SuiteClasses({ 
  ArchivesServerIntegrationTests.class })
public class AllTestsSuite {}
[4:41 PM] Rob Stryker: ArchivesServerIntegrationTests  has following:
@RunWith(RedDeerSuite.class)
@SuiteClasses({
  VariousProjectsArchiving.class,
  DeployingArchiveTest.class,
})
public class ArchivesServerIntegrationTests {
    
}
[4:41 PM] Rob Stryker: so its a nested suite
[4:41 PM] Rob Stryker: are these not supported?


result is 
`java.lang.Exception: No runnable methods
        at org.junit.runners.BlockJUnit4ClassRunner.validateInstanceMethods(BlockJUnit4ClassRunner.java:191)
        at org.junit.runners.BlockJUnit4ClassRunner.collectInitializationErrors(BlockJUnit4ClassRunner.java:128)
        at org.junit.runners.ParentRunner.validate(ParentRunner.java:416)
        at org.junit.runners.ParentRunner.<init>(ParentRunner.java:84)
        at org.junit.runners.BlockJUnit4ClassRunner.<init>(BlockJUnit4ClassRunner.java:65)
        at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.<init>(RequirementsRunner.java:110)
        at org.jboss.reddeer.junit.internal.runner.RequirementsRunnerBuilder.runnerForClass(RequirementsRunnerBuilder.java:109)
        at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
        at org.junit.runners.model.RunnerBuilder.runners(RunnerBuilder.java:101)
        at org.junit.runners.model.RunnerBuilder.runners(RunnerBuilder.java:87)
        at org.junit.runners.Suite.<init>(Suite.java:102)
        at org.junit.runners.Suite.<init>(Suite.java:70)
        at org.jboss.reddeer.junit.internal.runner.NamedSuite.<init>(NamedSuite.java:36)
        at org.jboss.reddeer.junit.runner.RedDeerSuite.createSuite(RedDeerSuite.java:100)
        at org.jboss.reddeer.junit.runner.RedDeerSuite.<init>(RedDeerSuite.java:79)
        at org.jboss.reddeer.junit.runner.RedDeerSuite.<init>(RedDeerSuite.java:66)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at org.junit.internal.builders.AnnotatedBuilder.buildRunner(AnnotatedBuilder.java:107)
        at org.junit.internal.builders.AnnotatedBuilder.runnerForClass(AnnotatedBuilder.java:86)
        at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
        at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:26)
        at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
        at org.junit.internal.requests.ClassRequest.getRunner(ClassRequest.java:33)
        at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.createUnfilteredTest(JUnit4TestLoader.java:84)
        at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.createTest(JUnit4TestLoader.java:70)
        at org.eclipse.jdt.internal.junit4.runner.JUnit4TestLoader.loadTests(JUnit4TestLoader.java:43)
        at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:444)
        at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)
        at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
        at org.jboss.reddeer.eclipse.core.RemotePluginTestRunner.main(RemotePluginTestRunner.java:68)
        at org.jboss.reddeer.eclipse.core.UITestApplication.runTests(UITestApplication.java:125)
        at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
        at java.lang.Thread.run(Thread.java:745)`