### PR TITLE
rev_Change test wait period tick to be smaller

### DIFF
--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/Wait.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/Wait.java
@@ -23,12 +23,12 @@ import org.jboss.reddeer.common.condition.WaitCondition;
 public interface Wait {
 	
 	/**
-	 * Waits for a specified time period to met wait condition.
+	 * Waits for a wait condition to met.
 	 * 
 	 * @param condition wait condition to met 
-	 * @param testPeriod time period to wait for
+	 * @param testPeriod test tick period in milliseconds
 	 */
-	public void wait(WaitCondition condition, TimePeriod testPeriod);
+	public void wait(WaitCondition condition, long testPeriod);
 	
 	/**
 	 * Gets info whether a condition should stop waiting or not.

--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/WaitUntil.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/WaitUntil.java
@@ -80,7 +80,7 @@ public class WaitUntil extends AbstractWait {
 	 * 
 	 */
 	public WaitUntil(WaitCondition condition, TimePeriod timeout,
-			boolean throwWaitTimeoutExpiredException, TimePeriod testPeriod) {
+			boolean throwWaitTimeoutExpiredException, long testPeriod) {
 		super(condition, timeout, throwWaitTimeoutExpiredException, testPeriod);
 	}
 	

--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/WaitWhile.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/WaitWhile.java
@@ -75,7 +75,7 @@ public class WaitWhile extends AbstractWait {
 	 * condition is performed
 	 */
 	public WaitWhile(WaitCondition condition, TimePeriod timeout,
-			boolean throwWaitTimeoutExpiredException, TimePeriod testPeriod) {
+			boolean throwWaitTimeoutExpiredException, long testPeriod) {
 		super(condition, timeout, throwWaitTimeoutExpiredException, testPeriod);
 	}
 	

--- a/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/WaitWrapper.java
+++ b/plugins/org.jboss.reddeer.common/src/org/jboss/reddeer/common/wait/WaitWrapper.java
@@ -89,7 +89,7 @@ public class WaitWrapper extends AbstractWait {
 	}
 	
 	@Override
-	public void wait(WaitCondition condition, TimePeriod testPeriod) {
+	public void wait(WaitCondition condition, long testPeriod) {
 		// NOTHING TO WAIT FOR
 	}
 }


### PR DESCRIPTION
Reasoning for this is that now wait with TimePeriod.SHORT and TimePeriod.NONE are equal.