### PR TITLE
Update/rewrite reddeer test suite run with requirements loaded from config file

### DIFF
--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/NullTestRunConfiguration.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/NullTestRunConfiguration.java
@@ -16,8 +16,6 @@ package org.jboss.reddeer.junit.internal.configuration;
  * @author rhopp
  *
  */
-
-
 public class NullTestRunConfiguration implements TestRunConfiguration {
 
 	private RequirementsConfiguration requirementsConfiguration;

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementConfiguration.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementConfiguration.java
@@ -1,0 +1,187 @@
+package org.jboss.reddeer.junit.internal.configuration;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.jboss.reddeer.junit.configuration.RedDeerConfigurationException;
+import org.jboss.reddeer.junit.internal.configuration.entity.PropertyBasedConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
+import org.jboss.reddeer.junit.requirement.CustomConfiguration;
+import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
+import org.jboss.reddeer.junit.requirement.Requirement;
+import org.jboss.reddeer.junit.requirement.RequirementException;
+
+/**
+ * Represents requirement configuration class and its configuration object defined in xml file.
+ * @author odockal
+ *
+ */
+public class RequirementConfiguration {
+	
+	private List<Object> configurations = new ArrayList<>();
+	
+	private Class<?> requirementConfigurationClass;
+	
+	/**
+	 * Instantiates requirement configuration object that consists of 
+	 * given requirement configuration class, xml reader as provider to configuration file and
+	 * gives access to all configuration based on given configuration class.
+	 * @param requirementConfigClass configuration class of the requirement
+	 * @param reader the reader
+	 */
+	public RequirementConfiguration(Class<?> requirementConfigClass, XMLReader reader) {
+		this.requirementConfigurationClass = requirementConfigClass;
+		readConfigurationFromXML(reader);
+	}
+	
+	/**
+	 * Returns list of configurations.
+	 * @return list of configuration objects
+	 */
+	public List<Object> getConfiguration() {
+		if (this.configurations.isEmpty()) {
+			throw new RedDeerConfigurationException("No configuration found in XML configuration file for requirement class " + this.requirementConfigurationClass);
+		}
+		return this.configurations;
+	}
+	
+	/**
+	 * Requirement configuration class.
+	 * @return requirement configuration class
+	 */
+	public Class<?> getRequirementConfiguration() {
+		return this.requirementConfigurationClass;
+	}
+	
+	/**
+	 * Based on given xml reader and instance's {@link requirementConfigurationClass} object
+	 * reads all applicable configuration from xml file that corresponds to configuration class and
+	 * insert them into instance's list of {@link configurations}. 
+	 * @param reader the reader
+	 */
+	private void readConfigurationFromXML(XMLReader reader) {
+		
+		@SuppressWarnings("unchecked")
+		Requirement<Annotation> requirement = (Requirement<Annotation>) createInstance(this.requirementConfigurationClass.getEnclosingClass());
+		
+		if (!(requirement instanceof CustomConfiguration || requirement instanceof PropertyConfiguration)){
+			throw new IllegalArgumentException("The requirement does not implement neither of " +
+												CustomConfiguration.class + " or " + PropertyConfiguration.class);
+		}
+		
+		List<Object> configurationList = new ArrayList<>();
+		
+		if (requirement instanceof CustomConfiguration) {
+		
+			// maybe use newInstance on annotation object (CustomConfiguration class)
+			@SuppressWarnings("unchecked")
+			CustomConfiguration<Object> customConfig = (CustomConfiguration<Object>) requirement;
+			
+			configurationList = reader.getConfiguration(customConfig.getConfigurationClass());
+		} else if (requirement instanceof PropertyConfiguration) {
+			
+			configurationList = loadPropertyConfigurations(reader);
+		}
+		this.configurations = configurationList;
+	}
+	
+	/**
+	 * Load property based configurations.
+	 * @param reader the xml reader
+	 * @return map containing property based configuration
+	 */
+	private List<Object> loadPropertyConfigurations(XMLReader reader) {
+		List<PropertyBasedConfiguration> list = reader.getConfiguration(PropertyBasedConfiguration.class);
+		List<Object> configurationList = new ArrayList<>();
+		
+		for (PropertyBasedConfiguration config : list) {
+			if (this.requirementConfigurationClass.getEnclosingClass().getCanonicalName().equalsIgnoreCase(config.getRequirementClassName())) {
+				configurationList.add(config);
+			}
+		}
+		return configurationList;
+	}
+	
+	/**
+	 * Iterate over all configurations and checks if any is applicable.
+	 * @param annotations all requirement annotations used
+	 */
+	public void checkRequirementConfiguration(List<Annotation> annotations) {
+		Iterator<Object> iterator = getConfiguration().iterator();
+		while(iterator.hasNext()) {
+			Object obj = iterator.next();
+			if (!configurationFitsRequirement(obj, annotations)) {
+				iterator.remove();
+			}
+		}
+	}
+	
+	/**
+	 * Tests whether given configuration is acceptable for any of given annotations.
+	 * @param configuration configuration instance or object, particular configuration values
+	 * @param annotations list of annotations
+	 * @return true, if configuration object fits requirement
+	 */
+	private boolean configurationFitsRequirement(Object configuration, List<Annotation> annotations) {
+		for (Annotation annotation : annotations) {
+			// test whether requirement is of particular configuration class
+			if (annotation.annotationType().getEnclosingClass() != this.requirementConfigurationClass.getEnclosingClass()) {
+				continue;
+			}
+			// build requirement/s
+			Requirement<?> requirement = buildRequirement(configuration, annotation);
+			if (requirement.isDeclarationAcceptable()){
+				return true;
+			} 
+		}
+		return false;
+	}
+	
+	/**
+	 * Builds requirement based on given annotation and sets its configuration.
+	 * @param configuration configuration instance or object, particular configuration values
+	 * @param annotation requirement annotation
+	 * @return requirement object with defined configuration
+	 */
+	@SuppressWarnings("unchecked")
+	private static Requirement<?> buildRequirement(Object configuration, Annotation annotation) {
+		Requirement<?> requirement = getRequirement(annotation);
+		CustomConfiguration<Object> requirementConfiguraiton = (CustomConfiguration<Object>) requirement;
+		requirementConfiguraiton.setConfiguration(configuration);
+		return requirement;
+	}
+	
+	/**
+	 * Returns Requirement object based on given annotation and
+	 * sets this annotation as requirement's declaration.
+	 * @param annotation requirement annotation
+	 * @return requirement object with set declaration
+	 */
+	@SuppressWarnings("unchecked")
+	public static Requirement<?> getRequirement(Annotation annotation){
+		Class<?> clazz = annotation.annotationType().getEnclosingClass();
+		Requirement<Annotation> requirement = (Requirement<Annotation>) createInstance(clazz);
+		requirement.setDeclaration(annotation);
+		//log.debug("Found requirement " + requirement.getClass() + " for annotation " + annotation);
+		return requirement;
+	}
+
+	/**
+	 * Creates instance of given class object.
+	 * @param clazz requirement class object to be instantiated
+	 * @return creates instance of Class&lt;?&gt; object
+	 */
+	private static Requirement<?> createInstance(Class<?> clazz) {
+		try {
+			return (Requirement<?>) clazz.newInstance();
+		} catch (InstantiationException e) {
+			throw new RequirementException("Error during instantiation of a requirement", e);
+		} catch (IllegalAccessException e) {
+			throw new RequirementException("Error during instantiation of a requirement", e);
+		} catch (NullPointerException e) {
+			throw new RequirementException("Error during instantiation of a null requirement object", e);
+		}
+	}
+}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementsConfigurationImpl.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/RequirementsConfigurationImpl.java
@@ -10,11 +10,12 @@
  ******************************************************************************/ 
 package org.jboss.reddeer.junit.internal.configuration;
 
+import java.util.List;
+
 import org.jboss.reddeer.junit.internal.configuration.configurator.CustomConfigurator;
 import org.jboss.reddeer.junit.internal.configuration.configurator.NullConfigurator;
 import org.jboss.reddeer.junit.internal.configuration.configurator.PropertyBasedConfigurator;
 import org.jboss.reddeer.junit.internal.configuration.configurator.RequirementConfigurator;
-import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
 import org.jboss.reddeer.junit.internal.configuration.setter.ConfigurationSetter;
 import org.jboss.reddeer.junit.requirement.CustomConfiguration;
 import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
@@ -31,7 +32,7 @@ import org.jboss.reddeer.junit.requirement.Requirement;
  * @author Lucia Jelinkova
  * @see TestRunConfiguration
  */
-public class RequirementsConfigurationImpl implements RequirementsConfiguration{
+public class RequirementsConfigurationImpl implements RequirementsConfiguration {
 	
 	private NullConfigurator voidConfigurator;
 	
@@ -42,19 +43,19 @@ public class RequirementsConfigurationImpl implements RequirementsConfiguration{
 	/**
 	 * Instantiates a new requirements configuration impl.
 	 *
-	 * @param reader the reader
+	 * @param configurations list of configurations values
 	 */
-	public RequirementsConfigurationImpl(XMLReader reader) {
+	public RequirementsConfigurationImpl(List<Object> configurations) {
 		super();
 		this.voidConfigurator = new NullConfigurator();
-		this.propertyConfigurator = new PropertyBasedConfigurator(reader, new ConfigurationSetter());
-		this.customConfigurator = new CustomConfigurator(reader);
+		this.propertyConfigurator = new PropertyBasedConfigurator(configurations, new ConfigurationSetter());
+		this.customConfigurator = new CustomConfigurator(configurations);
 	}
 	
 	/* (non-Javadoc)
 	 * @see org.jboss.reddeer.junit.internal.configuration.RequirementsConfiguration#configure(org.jboss.reddeer.junit.requirement.Requirement)
 	 */
-	public void configure(Requirement<?> requirement){
+	public void configure(Requirement<?> requirement) {
 		getConfigurator(requirement).configure(requirement);
 	}
 	
@@ -64,12 +65,12 @@ public class RequirementsConfigurationImpl implements RequirementsConfiguration{
 	 * @param requirement the requirement
 	 * @return the configurator
 	 */
-	public RequirementConfigurator getConfigurator(Requirement<?> requirement){
+	public RequirementConfigurator getConfigurator(Requirement<?> requirement) {
 		if (requirement instanceof PropertyConfiguration){
 			return propertyConfigurator;
 		}
 		
-		if (requirement instanceof CustomConfiguration<?>){
+		if (requirement instanceof CustomConfiguration<?>) {
 			return customConfigurator;
 		}
 		return voidConfigurator;

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/SuiteConfiguration.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/SuiteConfiguration.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -11,120 +11,268 @@
 package org.jboss.reddeer.junit.internal.configuration;
 
 import java.io.File;
-import java.io.FileFilter;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.common.properties.RedDeerProperties;
 import org.jboss.reddeer.junit.configuration.RedDeerConfigurationException;
+import org.jboss.reddeer.junit.internal.annotation.AnnotationsFinder;
+import org.jboss.reddeer.junit.internal.requirement.RequirementAnnotationMatcher;
+import org.jboss.reddeer.junit.requirement.CustomConfiguration;
+import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
+import org.jboss.reddeer.junit.requirement.Requirement;
+import org.junit.runners.Suite.SuiteClasses;
+import org.junit.runners.model.InitializationError;
 
 /**
- * Finds configuration files and provides access to that configuration.
- * 
- * The configuration files location is specified via a system property. It can points 
- * either to a single file or to a directory. Please note that the directory cannot contain any other files except for the
- * configuration files and that it is not processed recursively. 
- * 
+ * Class represents test suite configuration. Provides information about test classes' requirement annotations,
+ * finds all nested test classes, creates test run configuration reader that provides configuration for test runs
  * @author Lucia Jelinkova
+ * @author Ondrej Dockal
  *
  */
 public class SuiteConfiguration {
-
-    private static final Logger log = Logger.getLogger(SuiteConfiguration.class);
-	
-    private List<TestRunConfiguration> testRunConfigs;
     
+    private Class<?> suiteClass;
+    
+    private List<TestClassRequirementMap> annotatedTestClasses = new ArrayList<>();
+    
+    private List<Annotation> annotationRequirements = new ArrayList<>();
+    
+    private Map<TestClassRequirementMap, List<TestRunConfiguration>> testRunConfigurations = new HashMap<>();
+    
+	// helps to find annotations over class
+	private AnnotationsFinder finder = new AnnotationsFinder(new RequirementAnnotationMatcher());
+    
+    /**
+     * Constructor with class parameter
+     * @param clazz given class object
+     * @throws InitializationError if suite is null
+     */
+	public SuiteConfiguration(Class<?> clazz) throws InitializationError {
+		this.suiteClass = clazz;
+		readSubclassAnnotations();
+	}
+	
 	/**
-	 * Gets the test run configurations.
-	 *
-	 * @return the test run configurations
+	 * Creates test run configuration reader that harvest configuration file according to all requirements
+	 * that use configuration
+	 * @return test run configuration reader
 	 */
-	public List<TestRunConfiguration> getTestRunConfigurations(){
-		if (testRunConfigs == null){
-			testRunConfigs = findTestRunConfigurations();
+	public TestRunConfigurationReader getConfigurationFromFile() {
+		File file = getConfigurationFile();
+		return file == null ? null : new TestRunConfigurationReader(file, this.annotationRequirements);
+	}
+	
+	private void createTestRunConfigurations() {
+		TestRunConfigurationReader configurationReader = getConfigurationFromFile();
+		if (configurationReader != null) {
+			// we must create suite with its own list of test classes based on used annotations/requirements
+			// take all test classes that are grouped based on configuration requirements used
+			for (TestClassRequirementMap testClasses : getAnnotatedTestClasses()) {
+				List<TestRunConfiguration> testRuns = new ArrayList<>();
+				for (List<Object> list : getConfigurationMatrix(testClasses, configurationReader)) {
+					testRuns.add(list.isEmpty() ? new NullTestRunConfiguration() : new TestRunConfigurationImpl(list));
+				}
+				this.testRunConfigurations.put(testClasses, testRuns);
+			}
+		} else {
+			this.testRunConfigurations.put(new TestClassRequirementMap(new HashSet<>(), this.suiteClass), Arrays.asList(new NullTestRunConfiguration()));
 		}
-		return testRunConfigs;
+	}
+	
+	public List<TestClassRequirementMap> getAnnotatedTestClasses() {
+		return this.annotatedTestClasses;
 	}
 
-	private List<TestRunConfiguration> findTestRunConfigurations(){
-		List<TestRunConfiguration> configurations = new ArrayList<TestRunConfiguration>();
-		
-		log.info("Looking up configuration files defined via property " + RedDeerProperties.CONFIG_FILE.getName() + "=" + RedDeerProperties.CONFIG_FILE.getValue());
-		List<File> confFilesList = getConfigurationFiles();
-		if (confFilesList.isEmpty()){
-			log.info("No configuration file specified");
-			configurations.add(new NullTestRunConfiguration());
-			return configurations;
+	public Map<TestClassRequirementMap, List<TestRunConfiguration>> getTestRunConfigurations() {
+		if (this.testRunConfigurations == null || this.testRunConfigurations.isEmpty()) {
+			createTestRunConfigurations();
 		}
-		
-		for (File file :confFilesList){
-			log.info("Found configuration file " + file);
-			configurations.add(new TestRunConfigurationImpl(file));
+		return this.testRunConfigurations;
+	}
+	
+	/**
+	 * Returns cartesian product of all possible sets of configuration objects
+	 * @param testClasses test class requirement set object
+	 * @param reader test run config. reader
+	 * @return list of lists with all combination of read configurations
+	 */
+	@SuppressWarnings("unchecked")
+	private static <T> List<List<T>> getConfigurationMatrix(TestClassRequirementMap testClasses, TestRunConfigurationReader reader) {
+		/*
+		 * If set of configuration objects SCO1 = {A, B, C}, SCO2 = {1, 2} and SCO3 = {3, 4}
+		 * we will get list/set of results like this:
+		 * [A, 1, 3], [A, 1, 4], [A, 2, 3], [A, 2, 4],
+		 * [B, 1, 3], [B, 1, 4], [B, 2, 3], [B, 2, 4],
+		 * [C, 1, 3], [C, 1, 4], [C, 2, 3], [C, 2, 4]
+		 * but just in cases where any of test classes would contain such combination of requirements
+		 */
+		List<List<T>> lists = new ArrayList<>();
+		for (RequirementConfiguration configObject : reader.getConfigurationList()) {
+			if (testClasses.getRequirementConfiguration().contains(configObject.getRequirementConfiguration())) {
+				// we need to obtain all the lists of objects that will be used for cartesian product
+				lists.add((List<T>)configObject.getConfiguration());
+			}
 		}
-
-		return configurations;
+		return cartesianProduct(lists);
+	}
+	
+	/**
+	 * Cartesian product of given lists/sets
+	 * @param lists of all configurations
+	 * @return list of lists of all combinations of configurations
+	 */
+	private static <T> List<List<T>> cartesianProduct(List<List<T>> lists) {
+	    List<List<T>> resultLists = new ArrayList<List<T>>();
+	    if (lists.size() == 0) { // case where there is empty input list
+	        resultLists.add(new ArrayList<T>());
+	        return resultLists;
+	    } else {
+	    	// take first list
+	        List<T> firstList = lists.get(0); 
+	        // recursion called for remaining lists
+	        List<List<T>> remainingLists = cartesianProduct(lists.subList(1, lists.size())); 
+	        // for each configuration from first list
+	        for (T configuration : firstList) {
+	        	// and each remaining list
+	            for (List<T> remainingList : remainingLists) {
+	                ArrayList<T> resultList = new ArrayList<T>();
+	                resultList.add(configuration);
+	                resultList.addAll(remainingList);
+	                resultLists.add(resultList);
+	            }
+	        }
+	    }
+	    return resultLists;
+	}
+	
+	/**
+	 * Fills up annotationRequirements that holds all annotated requirements used for all test classes in suite
+	 * Groups together all test classes' requirement types and creates TestClassRequirementSet objects
+	 * @throws InitializationError if suite object is null
+	 */
+	private void readSubclassAnnotations() throws InitializationError {
+		if (this.suiteClass == null) {
+			throw new InitializationError("Suite class given is null");
+		}
+		List<Class<?>> listOfClasses = getTestClasses(this.suiteClass);
+		for (Class<?> clazz : listOfClasses) {
+			Set<Class<?>> requirements = getClassRequirements(clazz);
+			TestClassRequirementMap existingReqSet = getExistingRequirementSet(requirements);
+			// if null then add new set of requirements 
+			if (existingReqSet == null) {
+				this.annotatedTestClasses.add(new TestClassRequirementMap(requirements, clazz));
+			} else {
+				existingReqSet.addClass(clazz);
+			}
+		}
+	}
+	
+	/**
+	 * Gets all requirement annotations from specified class.
+	 * @param clazz
+	 * @return
+	 */
+	private Set<Class<?>> getClassRequirements(Class<?> clazz){
+		Set<Class<?>> requirements = new HashSet<>();
+		for (Annotation annotation : this.finder.find(clazz)) {
+			// check if requirement is implementing configuration
+			Requirement<?> requirement = RequirementConfiguration.getRequirement(annotation);
+			if (requirement instanceof CustomConfiguration || requirement instanceof PropertyConfiguration) {
+				this.annotationRequirements.add(annotation);
+				requirements.add(annotation.annotationType());
+			}
+		}
+		return requirements;
+	}
+	
+	/**
+	 * Returns test class requirement set object if such exists according to given set of classes
+	 * @param set set of requirements
+	 * @return test class requirement set if such exists
+	 */
+	private TestClassRequirementMap getExistingRequirementSet(Set<Class<?>> set) {
+		if(set != null){
+			for (TestClassRequirementMap classSet : this.annotatedTestClasses) {
+				if (classSet.equalAnnotationSet(set)) {
+					return classSet;
+				}
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * Tests whether class is class suite
+	 * @param clazz class to be checked
+	 * @return true if class given has SuiteClass annotation
+	 */
+	private boolean isSuite(Class<?> clazz) {
+		SuiteClasses annotation = clazz.getAnnotation(SuiteClasses.class);
+		return annotation != null;
+	}
+	
+	/**
+	 * Return list of all classes that the class given as a parameter could contains, uses recursion for nested suites
+	 * @param suiteClass class to be examined
+	 * @return list of all test classes
+	 */
+	private List<Class<?>> getTestClasses(Class<?> suiteClass) {
+		List<Class<?>> classes = new ArrayList<>();
+		// SuiteClass annotation is used with its test classes
+		SuiteClasses suiteAnnontation = suiteClass.getAnnotation(SuiteClasses.class);
+		if (suiteAnnontation != null) {
+	        for (Class<?> clazz : suiteAnnontation.value()) {
+	        	if (isSuite(clazz)) {
+	        		classes.addAll(getTestClasses(clazz));
+	        	} else {
+	        		classes.add(clazz);
+	        	}
+	        }
+	    // only one test class is run with RunWith(RedDeerSuite.class) annotation
+		} else {
+			classes.add(this.suiteClass);
+		}
+		return classes;
 	}
 
 	/**
 	 * 
-	 * Returns configuration files specified in a system property. It can be a single file 
-	 * or a directory where all files in that directory are returned (non recursively).
+	 * Returns configuration file specified in a system property. It can be a single file 
+	 * or a directory where only one configuration xml file is returned (non recursively).
 	 * 
-	 * @return List of configuration files
+	 * @return configuration file
 	 */
-	public List<File> getConfigurationFiles(){
+	public File getConfigurationFile(){
 		if (RedDeerProperties.CONFIG_FILE.getValue() == null){
-			return new ArrayList<File>();
+			return null;
 		}
 
-		return getConfigurationFiles(new File(RedDeerProperties.CONFIG_FILE.getValue()));
+		return getConfigurationFile(new File(RedDeerProperties.CONFIG_FILE.getValue()));
 	}
 
 	/**
-	 * Gets the configuration files.
+	 * Gets the configuration file.
 	 *
 	 * @param location the location
-	 * @return the configuration files
+	 * @return the configuration file
 	 */
-	public List<File> getConfigurationFiles(File location){
-		if (!location.exists()){
+	public File getConfigurationFile(File location) {
+		if (!location.exists()) {
 			throw new RedDeerConfigurationException("The configuration location " + location.getAbsolutePath() + " does not exist");
 		}
 
-		if (location.isFile()){
-			return Arrays.asList(location);
-		} else if (location.isDirectory()){
-			return getFiles(location);
+		if (location.isFile() && location.getName().endsWith(".xml")) {
+			return location;
 		} else {
-			throw new RedDeerConfigurationException("The configuration location " + location.getAbsolutePath() + " is nor a file nor a directory");
-		}
-	}
-
-	private List<File> getFiles(File dir) {
-		File[] files = dir.listFiles(new RequirementFileFilter());
-
-		if (files.length == 0){
-			throw new RedDeerConfigurationException("The configuration directory " + dir.getAbsolutePath() + " does not contain any files.");
-		}
-
-		return Arrays.asList(files);
-	}
-
-	private static class RequirementFileFilter implements FileFilter {
-
-		/*
-		 * Accept only *.xml files
-		 * @see java.io.FileFilter#accept(java.io.File)
-		 */
-		@Override
-		public boolean accept(File pathname) {
-			if (pathname.isFile() && pathname.toString().endsWith(".xml")) {
-				return true;
-			} else {
-				return false;
-			}
+			throw new RedDeerConfigurationException("The configuration location " + location.getAbsolutePath() + " must be a xml file");
 		}
 	}
 }

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/TestClassRequirementMap.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/TestClassRequirementMap.java
@@ -1,0 +1,68 @@
+package org.jboss.reddeer.junit.internal.configuration;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Class represents test class and set of requirement configuration classes used to run with it.
+ * Can hold more test classes for the same set of configurations.
+ * @author odockal
+ *
+ */
+public class TestClassRequirementMap {
+
+	private Set<Class<?>> requirementsConfiguration = new HashSet<>();
+	
+	private List<Class<?>> testClasses = new ArrayList<>();
+	
+	/**
+	 * Class constructor.
+	 * @param configs set of configuration classes
+	 * @param clazz test classes
+	 */
+	public TestClassRequirementMap(Set<Class<?>> configs, Class<?> clazz) {
+		this.requirementsConfiguration = configs;
+		addClass(clazz);
+	}
+	
+	/**
+	 * Add another test class.
+	 * @param clazz the test class
+	 */
+	public void addClass(Class<?> clazz) {
+		if (clazz != null) {
+			this.testClasses.add(clazz);
+		}
+	}
+	
+	/**
+	 * Checks whether set of req. configurations is equal to the given set.
+	 * @param set given set of configurations
+	 * @return true if the sets are equals, more formally: Two sets are equal if and only if they have the same elements. 
+	 */
+	public boolean equalAnnotationSet(Set<Class<?>> set) {
+		return this.requirementsConfiguration.containsAll(set) && set.containsAll(this.requirementsConfiguration);
+	}
+	
+	public List<Class<?>> getClasses() {
+		return this.testClasses;
+	}
+	
+	/**
+	 * Gets all test classes as an array.
+	 * @return all test classes as an array
+	 */
+	public Class<?>[] getClassesAsArray() {
+		return this.testClasses.toArray(new Class<?>[this.testClasses.size()]);
+	}
+	
+	/**
+	 * Returns requirement configurations set.
+	 * @return set of requirement configurations
+	 */
+	public Set<Class<?>> getRequirementConfiguration() {
+		return this.requirementsConfiguration;
+	}
+}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/TestRunConfigurationImpl.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/TestRunConfigurationImpl.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -10,59 +10,52 @@
  ******************************************************************************/ 
 package org.jboss.reddeer.junit.internal.configuration;
 
-import java.io.File;
-
-import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
+import java.util.List;
 
 /**
- * Configuration associated with one configuration file representing one run of the tests. 
+ * Configuration associated with one list of possible configurations representing one run of the tests. 
  * 
  * @author Lucia Jelinkova
+ * @author Ondrej Dockal
  *
  */
 public class TestRunConfigurationImpl implements TestRunConfiguration {
 
-	private File file;
-	
-	private String id;
-	
-	private XMLReader configurationReader;
+	private String id = "";
+
+	private List<Object> configurationSet;
 	
 	private RequirementsConfiguration requirementsConfiguration;
 	
 	/**
 	 * Instantiates a new test run configuration impl.
 	 *
-	 * @param file the file
+	 * @param configurations list of configurations values
 	 */
-	public TestRunConfigurationImpl(File file) {
-		this.file = file;
+	public TestRunConfigurationImpl(List<Object> configurations) {
+		this.configurationSet = configurations;
 	}
 	
 	/* (non-Javadoc)
 	 * @see org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration#getId()
 	 */
 	public String getId() {
-		if (id == null){
-			id = file.getName();
+		if (id.isEmpty()){
+			for (Object config : configurationSet) {
+				if (!id.isEmpty()) id += " ";
+				id += config.getClass().getSimpleName();
+			}
 		}
-		return id;
+		return !id.isEmpty() ? id : "Empty Configuration";
 	}
 	
 	/* (non-Javadoc)
 	 * @see org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration#getRequirementConfiguration()
 	 */
-	public RequirementsConfiguration getRequirementConfiguration(){
+	public RequirementsConfiguration getRequirementConfiguration() {
 		if (requirementsConfiguration == null){
-			requirementsConfiguration = new RequirementsConfigurationImpl(getConfigurationReader());
+			requirementsConfiguration = new RequirementsConfigurationImpl(this.configurationSet);
 		}
 		return requirementsConfiguration;
-	}
-	
-	private XMLReader getConfigurationReader() {
-		if (configurationReader == null){
-			configurationReader = new XMLReader(file);
-		}
-		return configurationReader;
 	}
 }

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/TestRunConfigurationReader.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/TestRunConfigurationReader.java
@@ -1,0 +1,99 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.junit.internal.configuration;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
+import org.jboss.reddeer.junit.requirement.CustomConfiguration;
+
+/**
+ * Provides set of all configuration classes obtained from given list of requirements.
+ * Creates XML reader and processes xml file that contains test run configurations and groups them into 
+ * list of all configurations represented by {@link RequirementConfiguration}.
+ * @author Ondrej Dockal
+ *
+ */
+public class TestRunConfigurationReader {
+	
+	private XMLReader reader;
+	
+	// all requirements configuration classes, used for reading of xml config file
+	private Set<Class<?>> allRequirementConfigurations = new HashSet<>();
+	
+	// all requirements that test classes use, used for cleaning up of requirement configuration that will not be used
+	private List<Annotation> allRequirements;
+	
+	private List<RequirementConfiguration> configurationList;
+	
+	/**
+	 * Class instance that sets up requirement configuration classes and list of {@link RequirementConfiguration}.
+	 * @param file the configuration xml file
+	 * @param requirements list of all requirements
+	 */
+	public TestRunConfigurationReader(File file, List<Annotation> requirements) {
+		this.reader = new XMLReader(file);
+		this.allRequirements = requirements;
+		this.configurationList = new ArrayList<>();
+		
+		setRequirementConfigurationClasses();
+		// uses loaded req. configurations to read configurations from config.xml file
+		readConfigurationXML();
+		// deletes configuration that will not be used by any test class requirements
+		cleanUpRequirementConfiguration();
+		// mix up all possible configuration
+	}
+	
+	/**
+	 * Loads requirement configuration classes.
+	 */
+	private void setRequirementConfigurationClasses() {
+		for (Annotation annotation : this.allRequirements) {
+			this.allRequirementConfigurations.add(annotation.annotationType());
+		}
+	}
+	
+	/**
+	 * Returns configuration list.
+	 * @return list of requirement configuration objects
+	 */
+	public List<RequirementConfiguration> getConfigurationList() {
+		return this.configurationList;
+	}
+	
+	/**
+	 * Clean up unused configurations according to its requirements.
+	 */
+	private void cleanUpRequirementConfiguration() {
+		for (RequirementConfiguration config : this.configurationList) {
+			if (config.getRequirementConfiguration() == CustomConfiguration.class) {
+				config.checkRequirementConfiguration(this.allRequirements);
+			}
+		}
+	}
+	
+	/**
+	 * Iterate over all requirement configuration classes
+	 * used with test classes and add new {@link RequirementConfiguration} object
+	 * into configuration list 
+	 */
+	private void readConfigurationXML() {
+		for (Class<?> clazz : this.allRequirementConfigurations) {
+			this.configurationList.add(new RequirementConfiguration(clazz, reader));
+		}
+	}
+	
+}

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/configurator/CustomConfigurator.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/configurator/CustomConfigurator.java
@@ -14,39 +14,39 @@ import java.util.List;
 
 import org.jboss.reddeer.common.logging.Logger;
 import org.jboss.reddeer.junit.configuration.RedDeerConfigurationException;
-import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
 import org.jboss.reddeer.junit.requirement.CustomConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
 
 /**
- * Reads custom configuration from XML file and sets the configuration into the requirement. 
+ * Sets one of custom configuration from the given list into the requirement. 
  * 
- * @author Lucia Jelinkova
+ * @author Lucia Jelinkova, Ondrej Dockal
  *
  */
-public class CustomConfigurator implements RequirementConfigurator{
+public class CustomConfigurator implements RequirementConfigurator {
 
 	private static final Logger log = Logger.getLogger(CustomConfigurator.class);
 	
-	private XMLReader reader;
+	private List<Object> configurations;
 	
 	/**
 	 * Instantiates a new custom configurator.
 	 *
-	 * @param reader the reader
+	 * @param configurations list of configurations
 	 */
-	public CustomConfigurator(XMLReader reader) {
-		super();
-		this.reader = reader;
+	public CustomConfigurator(List<Object> configurations) {
+		this.configurations = configurations;
 	}
 
-	/* (non-Javadoc)
-	 * @see org.jboss.reddeer.junit.internal.configuration.configurator.RequirementConfigurator#configure(org.jboss.reddeer.junit.requirement.Requirement)
+	/**
+	* Iterate over all configurations and tries to cast the configuration object to expected configuration class
+	* that must implement {@link CustomConfiguration}.
+	* If none of configuration is set, then the {@link RedDeerConfigurationException} is thrown.
 	 */
 	@Override
 	public void configure(Requirement<?> requirement) {
 		
-		if (!(requirement instanceof CustomConfiguration<?>)){
+		if (!(requirement instanceof CustomConfiguration<?>)) {
 			throw new IllegalArgumentException("The requirement does not implement " + CustomConfiguration.class);
 		}
 		
@@ -57,16 +57,19 @@ public class CustomConfigurator implements RequirementConfigurator{
 		
 		log.debug("Configuration object associated with requirement " + requirement.getClass() + " is " + customConfiguration.getConfigurationClass());
 		
-		List<Object> configs = reader.getConfiguration(customConfiguration.getConfigurationClass());
-		if (configs.isEmpty()){
-			throw new RedDeerConfigurationException("No configuration found in XML configuration file for requirement class " + customConfiguration.getClass());
+		boolean configurationSet = false;
+		for (Object configuration : this.configurations) {
+			if(customConfiguration.getConfigurationClass().isAssignableFrom(configuration.getClass())){
+				customConfiguration.setConfiguration(configuration);
+				log.debug("Configuration successfully set");		
+				configurationSet = true;
+				break;
+			}
 		}
-		
-		if (configs.size() > 1){
-			throw new RedDeerConfigurationException("More then one configuration found in XML configuration file for requirement class " + customConfiguration.getClass());
+		if (!configurationSet) {
+			throw new RedDeerConfigurationException("None of the given configurations "
+					+ "could have ben set as configuration of the requirement " + requirement.getClass().getName());
 		}
-		
-		customConfiguration.setConfiguration(configs.get(0));
-		log.debug("Configuration successfully set");
+
 	}
 }

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/entity/PropertyBasedConfiguration.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/entity/PropertyBasedConfiguration.java
@@ -17,8 +17,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.jboss.reddeer.junit.requirement.Requirement;
-
 /**
  * JAXB annotated class for reading the default (property based) configuration.
  * 
@@ -32,8 +30,8 @@ public class PropertyBasedConfiguration {
 
 	private String clazz;
 
-	private Class<? extends Requirement<?>> className;
-
+	private String requirementName;
+	
 	/**
 	 * Sets the properties.
 	 *
@@ -61,6 +59,15 @@ public class PropertyBasedConfiguration {
 	public void setRequirementClassName(String clazz) {
 		this.clazz = clazz;
 	}
+	
+	/**
+	 * Sets the requirement name.
+	 * 
+	 * @param requirementName the name of requirement
+	 */
+	public void setRequirementName(String requirementName) {
+		this.requirementName = requirementName;
+	}
 
 	/**
 	 * Gets the requirement class name.
@@ -70,5 +77,14 @@ public class PropertyBasedConfiguration {
 	@XmlAttribute(name = "class")
 	public String getRequirementClassName() {
 		return clazz;
+	}
+	
+	/**
+	 * Gets the requirement name.
+	 * @return Name of the requirement that is unique
+	 */
+	@XmlAttribute(name = "name")
+	public String getRequirementName() {
+		return requirementName;
 	}
 }

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/setter/ConfigurationSetter.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/configuration/setter/ConfigurationSetter.java
@@ -28,7 +28,7 @@ import org.jboss.reddeer.junit.requirement.Requirement;
 public class ConfigurationSetter {
 
 	/**
-	 * Sets the.
+	 * Sets the 
 	 *
 	 * @param requirement the requirement
 	 * @param configuration the configuration
@@ -39,7 +39,7 @@ public class ConfigurationSetter {
 		}
 	}
 	
-	private void inject(Requirement<?> requirement, Property property){
+	private void inject(Requirement<?> requirement, Property property) {
 		inject(requirement, property.getKey(), property.getValue());
 	}
 	

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/RequirementsBuilder.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/requirement/RequirementsBuilder.java
@@ -44,8 +44,9 @@ public class RequirementsBuilder {
 		checkArguments(clazz, config);
 		List<Requirement<?>> requirements = new ArrayList<Requirement<?>>();
 		
-		log.info("Creating requirements for test " + clazz);
-		for (Annotation annotation : finder.find(clazz)){
+		log.info("Build method - Creating requirements for test " + clazz);
+		for (Annotation annotation : this.finder.find(clazz)){
+			log.info("### adding builded configuration for annotation " + annotation.toString());
 			requirements.add(build(annotation, config));
 		}
 		

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunner.java
@@ -134,7 +134,7 @@ public class RequirementsRunner extends BlockJUnit4ClassRunner {
 	@Override
 	public Object createTest() throws Exception {
 		Object testInstance = super.createTest();
-		log.debug("Injecting fulfilled requirements into test instance");
+		log.debug("Injecting fulfilled requirements into test instance: " + requirements.getClass().getName());
 		requirementsInjector.inject(testInstance, requirements);
 		return testInstance;
 	}
@@ -246,7 +246,7 @@ public class RequirementsRunner extends BlockJUnit4ClassRunner {
 	
 	@Override
 	protected Statement classBlock(final RunNotifier notifier) {
-		log.debug("Injecting fulfilled requirements into static fields of test class");
+		log.debug("Injecting fulfilled requirements into static fields of test class: " + requirements.getClass().getName());
 		requirementsInjector.inject(getTestClass().getJavaClass(), requirements);
 		
 		return super.classBlock(notifier);

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/internal/runner/RequirementsRunnerBuilder.java
@@ -21,15 +21,11 @@ import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
 import org.jboss.reddeer.junit.internal.requirement.Requirements;
 import org.jboss.reddeer.junit.internal.requirement.RequirementsBuilder;
 import org.junit.Ignore;
-import org.junit.Test;
 import org.junit.runner.Runner;
 import org.junit.runner.notification.RunListener;
-import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Suite;
-import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
-import org.junit.runners.model.TestClass;
 
 /**
  * Checks if the requirements on the test class can be fulfilled and creates a runner for the test class or
@@ -98,13 +94,14 @@ public class RequirementsRunnerBuilder extends RunnerBuilder {
 		if (clazz.getAnnotation(Ignore.class) != null) {
 			return new IgnoredClassRunner(clazz);
 		}
-		if(clazz.getAnnotation(Suite.SuiteClasses.class) != null){
+		if(clazz.getAnnotation(Suite.SuiteClasses.class) != null) { 
 			return new Suite(clazz, this);
 		}
 		log.info("Found test " + clazz);
 		if(testsManager != null) {
 			testsManager.addTest(clazz);
 		}
+		// here comes all the logic of loading a config and connecting them with requirements
 		Requirements requirements = requirementsBuilder.build(clazz, config.getRequirementConfiguration(), config.getId());
 		if (requirements.canFulfill()){
 			log.info("All requirements can be fulfilled, the test will run");

--- a/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/Requirement.java
+++ b/plugins/org.jboss.reddeer.junit/src/org/jboss/reddeer/junit/requirement/Requirement.java
@@ -58,5 +58,5 @@ public interface Requirement<T extends Annotation> extends IExecutionPriority {
 	default long getPriority() {
 		return 0;
 	}
-	
 }
+

--- a/plugins/org.jboss.reddeer.requirements/resources/v1/ServerRequirementsBase.xsd
+++ b/plugins/org.jboss.reddeer.requirements/resources/v1/ServerRequirementsBase.xsd
@@ -5,7 +5,7 @@
 
 	<!-- Import basic RedDeer requirements -->
 	<xs:import namespace="http://www.jboss.org/NS/Req"
-		schemaLocation="http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd" />
+		schemaLocation="http://www.jboss.org/schema/reddeer/RedDeerSchema.xsd" />
 
 	<!-- Specify user-requirement -->
 	<xs:element name="server-requirement" type="server:serverRequirementType"

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/jre/JRERequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/jre/JRERequirement.java
@@ -84,7 +84,7 @@ public class JRERequirement implements Requirement<JRE>, CustomConfiguration<JRE
 			return false;
 		}
 	}
-
+	
 	/**
 	 * Adds new JRE using Preferences &gt; Java &gt; Installed JRE's, Add JRE wizard.
 	 */

--- a/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/server/apache/tomcat/DummyServerRequirement.java
+++ b/plugins/org.jboss.reddeer.requirements/src/org/jboss/reddeer/requirements/server/apache/tomcat/DummyServerRequirement.java
@@ -1,0 +1,87 @@
+package org.jboss.reddeer.requirements.server.apache.tomcat;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jboss.reddeer.common.logging.Logger;
+import org.jboss.reddeer.junit.requirement.CustomConfiguration;
+import org.jboss.reddeer.junit.requirement.Requirement;
+import org.jboss.reddeer.requirements.server.ConfiguredServerInfo;
+import org.jboss.reddeer.requirements.server.ServerReqBase;
+import org.jboss.reddeer.requirements.server.apache.tomcat.ServerRequirementConfig;
+import org.jboss.reddeer.requirements.server.apache.tomcat.DummyServerRequirement.DummyServer;
+
+public class DummyServerRequirement extends ServerReqBase
+	implements Requirement<DummyServer>, CustomConfiguration<ServerRequirementConfig> {
+
+	private static final Logger log = Logger.getLogger(DummyServerRequirement.class);
+	
+	private ServerRequirementConfig config;
+	private DummyServer server;
+	
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public @interface DummyServer {
+		
+	}
+
+
+	@Override
+	public boolean canFulfill() {
+		return true;
+	}
+
+	@Override
+	public void fulfill() {
+		log.info("Fulfilling requirement");
+		log.info(this.server.annotationType().getAnnotations().toString());
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.reddeer.junit.requirement.Requirement#setDeclaration(java.lang.annotation.Annotation)
+	 */
+	@Override
+	public void setDeclaration(DummyServer server) {
+		this.server = server;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.reddeer.junit.requirement.CustomConfiguration#getConfigurationClass()
+	 */
+	@Override
+	public Class<ServerRequirementConfig> getConfigurationClass() {
+		return ServerRequirementConfig.class;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.jboss.reddeer.junit.requirement.CustomConfiguration#setConfiguration(java.lang.Object)
+	 */
+	@Override
+	public void setConfiguration(ServerRequirementConfig config) {
+		this.config = config;
+	}
+
+	/**
+	 * Gets the config.
+	 *
+	 * @return the config
+	 */
+	public ServerRequirementConfig getConfig() {
+		return this.config;
+	}
+
+	@Override
+	public void cleanUp() {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public ConfiguredServerInfo getConfiguredConfig() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+}

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/integration/configuration/requirements.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/integration/configuration/requirements.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer 
+	xmlns="http://www.jboss.org/NS/Req" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:java="http://www.jboss.org/NS/JavaReq"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd">
+
+	<requirements>
+	
+		<requirement class="org.jboss.reddeer.junit.test.integration.configuration.RequirementA" name="req1">
+			<property key="a" value="1" />
+		</requirement>
+		<requirement class="org.jboss.reddeer.junit.test.integration.configuration.RequirementB" name="req2">
+			<property key="b" value="2" />
+			<property key="a" value="3" />
+		</requirement>
+		
+		<java:java-requirement name="javaReq">
+			<java:version>1.7</java:version>
+			<java:runtime>/home/java</java:runtime>
+		</java:java-requirement>
+		
+		<!-- Usage of multiple requirements -->
+		<requirement class="org.jboss.reddeer.junit.test.integration.configuration.RequirementA" name="req1a">
+			<property key="a" value="10" />
+		</requirement>
+		<requirement class="org.jboss.reddeer.junit.test.integration.configuration.RequirementB" name="req2a">
+			<property key="b" value="20" />
+			<property key="a" value="30" />
+		</requirement>
+		
+		<java:java-requirement name="javaReq2">
+			<java:runtime>/java</java:runtime>
+		</java:java-requirement>
+	</requirements>
+</reddeer>

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/integration/runner/order/fileC.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/integration/runner/order/fileC.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer xmlns="http://www.jboss.org/NS/Req" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd http://www.jboss.org/NS/JavaReq JavaRequirements.xsd"
+	xmlns:java="http://www.jboss.org/NS/JavaReq">
+
+	<requirements>
+	
+		<requirement class="org.jboss.reddeer.junit.runner.integration.RunnerIntegrationPropertyRequirement" name="req1">
+			<property key="a" value="1" />
+		</requirement>
+		<requirement class="org.jboss.reddeer.junit.runner.integration.RunnerIntegrationPropertyRequirement" name="req2">
+			<property key="a" value="2" />
+		</requirement>
+		
+		<java:java-requirement name="javaReq">
+			<java:version>1.6</java:version>
+			<java:runtime>/home/java</java:runtime>
+		</java:java-requirement>
+		
+		<java:java-requirement name="javaReq">
+			<java:version>1.6</java:version>
+			<java:runtime>/home/java</java:runtime>
+		</java:java-requirement>
+	</requirements>
+</reddeer>

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/internal/configuration/dirWithConfig/correct_file.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/internal/configuration/dirWithConfig/correct_file.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Empty xml just to test correct SuiteConfiguration behavior-->

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/internal/configuration/dirWithConfig/requirements.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/internal/configuration/dirWithConfig/requirements.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer 	
+	xmlns="http://www.jboss.org/NS/Req" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:server="http://www.jboss.org/NS/ServerReq"
+	xmlns:jre="http://www.jboss.org/NS/jre-schema"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd
+						http://www.jboss.org/NS/jre-schema http://www.jboss.org/schema/reddeer/v1/JRERequirement.xsd
+						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/v1/ApacheServerRequirements.xsd">
+
+	<requirements>
+		<!-- Server configuration -->
+		<server:server-requirement name="Tomcat7">
+			<server:type>
+				<server:familyApacheTomcat version="7.0" />
+			</server:type>
+			<server:runtime>/home/server</server:runtime>
+		</server:server-requirement>
+		
+		<!-- JRE requirement definition -->
+		<jre:jre-requirement name="JRE-1.7">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.7</jre:version>
+        	<jre:path>/home/java</jre:path>
+		</jre:jre-requirement>   
+	</requirements>
+</reddeer>

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer 	
+	xmlns="http://www.jboss.org/NS/Req" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:server="http://www.jboss.org/NS/ServerReq"
+	xmlns:jre="http://www.jboss.org/NS/jre-schema"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd
+						http://www.jboss.org/NS/jre-schema http://www.jboss.org/schema/reddeer/v1/JRERequirement.xsd
+						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/v1/ApacheServerRequirements.xsd">
+
+	<requirements>
+		<!-- Server configuration -->
+		<server:server-requirement name="Tomcat7">
+			<server:type>
+				<server:familyApacheTomcat version="7.0" />
+			</server:type>
+			<server:runtime>/home/server</server:runtime>
+		</server:server-requirement>
+		
+		<!-- JRE requirement definition -->
+		<jre:jre-requirement name="JRE-1.7">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.7</jre:version>
+        	<jre:path>/home/java</jre:path>
+		</jre:jre-requirement>   
+	</requirements>
+</reddeer>

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements2.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements2.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer 	
+	xmlns="http://www.jboss.org/NS/Req" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:server="http://www.jboss.org/NS/ServerReq"
+	xmlns:jre="http://www.jboss.org/NS/jre-schema"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd
+						http://www.jboss.org/NS/jre-schema http://www.jboss.org/schema/reddeer/v1/JRERequirement.xsd
+						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/v1/ApacheServerRequirements.xsd">
+
+	<requirements>
+		<!-- Server configuration -->
+		<server:server-requirement name="Tomcat7">
+			<server:type>
+				<server:familyApacheTomcat version="7.0" />
+			</server:type>
+			<server:runtime>/home/server</server:runtime>
+		</server:server-requirement>
+		
+		<server:server-requirement name="Tomcat8">
+			<server:type>
+				<server:familyApacheTomcat version="8.0" />
+			</server:type>
+			<server:runtime>/home/server8</server:runtime>
+		</server:server-requirement>
+		
+		<!-- JRE requirement definition -->
+		<jre:jre-requirement name="JRE-1.7">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.7</jre:version>
+        	<jre:path>/home/java</jre:path>
+		</jre:jre-requirement>
+		
+		<jre:jre-requirement name="JRE-1.8">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.8</jre:version>
+        	<jre:path>/home/java8</jre:path>
+		</jre:jre-requirement>  
+	</requirements>
+</reddeer>

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements3.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements3.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer 	
+	xmlns="http://www.jboss.org/NS/Req" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd">
+
+	<requirements>
+		<!-- Properties configuration -->
+		<requirement class="org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA" name="req1">
+			<property key="property1" value="1" />
+		</requirement>
+		<requirement class="org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA" name="req1A">
+			<property key="property1" value="10" />
+		</requirement>
+				
+		<requirement class="org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementB" name="req2">
+			<property key="property1" value="2" />
+			<property key="property2" value="3" />
+		</requirement> 
+	</requirements>
+</reddeer>

--- a/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements4.xml
+++ b/tests/org.jboss.reddeer.junit.test/resources/org/jboss/reddeer/junit/test/runner/requirements4.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer 	
+	xmlns="http://www.jboss.org/NS/Req" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:server="http://www.jboss.org/NS/ServerReq"
+	xmlns:jre="http://www.jboss.org/NS/jre-schema"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd
+						http://www.jboss.org/NS/jre-schema http://www.jboss.org/schema/reddeer/v1/JRERequirement.xsd
+						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/v1/ApacheServerRequirements.xsd">
+
+	<requirements>
+		<!-- Server configuration -->
+		<server:server-requirement name="Tomcat7">
+			<server:type>
+				<server:familyApacheTomcat version="7.0" />
+			</server:type>
+			<server:runtime>/home/server</server:runtime>
+		</server:server-requirement>
+		
+		<server:server-requirement name="Tomcat8">
+			<server:type>
+				<server:familyApacheTomcat version="8.0" />
+			</server:type>
+			<server:runtime>/home/server8</server:runtime>
+		</server:server-requirement>
+		
+		<!-- JRE requirement definition -->
+		<jre:jre-requirement name="JRE-1.7">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.7</jre:version>
+        	<jre:path>/home/java</jre:path>
+		</jre:jre-requirement>
+		
+		<jre:jre-requirement name="JRE-1.8">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.8</jre:version>
+        	<jre:path>/home/java8</jre:path>
+		</jre:jre-requirement> 
+		
+		<!-- Properties configuration -->
+		<requirement class="org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA" name="req1">
+			<property key="property1" value="1" />
+		</requirement>
+		
+		<requirement class="org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementB" name="req2">
+			<property key="property1" value="2" />
+			<property key="property2" value="3" />
+		</requirement> 
+				
+		<requirement class="org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementB" name="req2B">
+			<property key="property1" value="20" />
+			<property key="property2" value="30" />
+		</requirement>   
+	</requirements>
+</reddeer>

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/execution/ExecutionTestRedDeerSuite.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/execution/ExecutionTestRedDeerSuite.java
@@ -35,7 +35,7 @@ public class ExecutionTestRedDeerSuite extends Suite {
 	
 	public ExecutionTestRedDeerSuite(Class<?> clazz, RunnerBuilder builder)
 			throws InitializationError {
-		this(clazz, builder, new SuiteConfiguration());
+		this(clazz, builder, new SuiteConfiguration(clazz));
 	}
 
 	protected ExecutionTestRedDeerSuite(Class<?> clazz, RunnerBuilder builder,

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/configuration/ComplexConfigurationTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/configuration/ComplexConfigurationTest.java
@@ -14,36 +14,48 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.jboss.reddeer.common.properties.RedDeerProperties;
 import org.jboss.reddeer.junit.internal.configuration.RequirementsConfiguration;
 import org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration;
 import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
-import org.junit.Before;
+import org.jboss.reddeer.junit.test.integration.configuration.JavaRequirement.CustomConfigJavaRequirementAAnnotation;
+import org.jboss.reddeer.junit.test.integration.configuration.RequirementA.RequirementAAnnotation;
+import org.jboss.reddeer.junit.test.integration.configuration.RequirementB.RequirementBAnnotation;
 import org.junit.Test;
+import org.junit.runners.model.InitializationError;
 
 public class ComplexConfigurationTest {
 
-	@Before
-	public void setup(){
-		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), "resources/org/jboss/reddeer/junit/integration/configuration");
+	private SuiteConfiguration config;
+	
+	@Test
+	public void numberOfTestRunsNoConfig() throws InitializationError {
+		config = new SuiteConfiguration(TestSuite.class);
+		assertThat(getTestRunConfigurationCount(config.getTestRunConfigurations().values()), is(1));
 	}
 	
 	@Test
-	public void numberOfTestRuns(){
-		SuiteConfiguration suiteConfiguration = new SuiteConfiguration();
-		List<TestRunConfiguration> testRunConfigutaions = suiteConfiguration.getTestRunConfigurations();
-		
-		assertThat(testRunConfigutaions.size(), is(2));
+	public void numberOfTestRunsWithConfig() throws InitializationError {
+		config = new SuiteConfiguration(RequirementABClass1.class);
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				"resources/org/jboss/reddeer/junit/integration/configuration/requirements.xml");
+		assertThat(getTestRunConfigurationCount(config.getTestRunConfigurations().values()), is(4));
 	}
-	
+
 	@Test
-	public void testRunA(){
-		SuiteConfiguration suiteConfiguration = new SuiteConfiguration();
-		List<TestRunConfiguration> testRunConfigutaions = suiteConfiguration.getTestRunConfigurations();
-		RequirementsConfiguration requirementsConfiguration = getTestRunById(testRunConfigutaions, "requirementsA.xml").getRequirementConfiguration();
+	public void testRunA() throws InitializationError {
+		SuiteConfiguration suiteConfiguration = new SuiteConfiguration(AllRequirementsClass.class);
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				"resources/org/jboss/reddeer/junit/integration/configuration/requirementsA.xml");
 		
+		assertThat(suiteConfiguration.getTestRunConfigurations().keySet().size(), is(1));
+		
+		List<TestRunConfiguration> list = suiteConfiguration.getTestRunConfigurations().values().iterator().next();
+		RequirementsConfiguration requirementsConfiguration = list.get(0).getRequirementConfiguration();
+
 		RequirementA requirementA = new RequirementA();
 		RequirementB requirementB = new RequirementB();
 		JavaRequirement javaRequirement = new JavaRequirement();
@@ -62,11 +74,14 @@ public class ComplexConfigurationTest {
 	}
 	
 	@Test
-	public void testRunb(){
-		SuiteConfiguration suiteConfiguration = new SuiteConfiguration();
-		List<TestRunConfiguration> testRunConfigutaions = suiteConfiguration.getTestRunConfigurations();
-		RequirementsConfiguration requirementsConfiguration = getTestRunById(testRunConfigutaions, "requirementsB.xml").getRequirementConfiguration();
+	public void testRunB() throws InitializationError {
+		SuiteConfiguration suiteConfiguration = new SuiteConfiguration(AllRequirementsClass.class);
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), "resources/org/jboss/reddeer/junit/integration/configuration/requirementsB.xml");
 		
+		assertThat(suiteConfiguration.getTestRunConfigurations().keySet().size(), is(1));
+		
+		List<TestRunConfiguration> list = suiteConfiguration.getTestRunConfigurations().values().iterator().next();
+		RequirementsConfiguration requirementsConfiguration = list.get(0).getRequirementConfiguration();
 		RequirementA requirementA = new RequirementA();
 		RequirementB requirementB = new RequirementB();
 		JavaRequirement javaRequirement = new JavaRequirement();
@@ -84,12 +99,40 @@ public class ComplexConfigurationTest {
 		assertThat(javaRequirement.getConfig().getVersion(), nullValue());
 	}
 	
-	private TestRunConfiguration getTestRunById(List<TestRunConfiguration> testRunConfigutaions, String id) {
-		for (TestRunConfiguration config : testRunConfigutaions){
-			if (id.equals(config.getId())){
-				return config;
-			}
-		}
-		throw new AssertionError("The required test run config was not present: " + id);
+	@Test
+	public void testRunAll() throws InitializationError {
+		SuiteConfiguration suiteConfiguration = new SuiteConfiguration(AllRequirementsClass.class);
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), "resources/org/jboss/reddeer/junit/integration/configuration/requirements.xml");
+		
+		assertThat(suiteConfiguration.getTestRunConfigurations().keySet().size(), is(1));
+		assertThat(suiteConfiguration.getTestRunConfigurations().values().iterator().next().size(), is(8));
 	}
+	
+	private int getTestRunConfigurationCount(Collection<List<TestRunConfiguration>> collection) {
+		short testCount = 0;
+		for (List<TestRunConfiguration> testRuns : collection) {
+			testCount += testRuns.size();
+		}
+		return testCount;
+	}
+	
+	private static class TestSuite {}
+	
+	@RequirementAAnnotation
+	private static class RequirementAClass1 {}
+	
+	@RequirementBAnnotation
+	private static class RequirementBClass1 {}
+	
+	@CustomConfigJavaRequirementAAnnotation
+	private static class RequirementJavaClass {}
+	
+	@RequirementAAnnotation
+	@RequirementBAnnotation
+	private static class RequirementABClass1 {}
+	
+	@RequirementAAnnotation
+	@RequirementBAnnotation
+	@CustomConfigJavaRequirementAAnnotation
+	private static class AllRequirementsClass {}
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/configuration/RequirementA.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/configuration/RequirementA.java
@@ -10,13 +10,23 @@
  ******************************************************************************/ 
 package org.jboss.reddeer.junit.test.integration.configuration;
 
-import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.jboss.reddeer.junit.test.integration.configuration.RequirementA.RequirementAAnnotation;
 
 import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
 
-public class RequirementA implements Requirement<Annotation>, PropertyConfiguration {
+public class RequirementA implements Requirement<RequirementAAnnotation>, PropertyConfiguration {
 
+	
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public @interface RequirementAAnnotation {
+	}	
+	
 	private String a;
 	
 	public boolean canFulfill() {
@@ -35,12 +45,11 @@ public class RequirementA implements Requirement<Annotation>, PropertyConfigurat
 	}
 	
 	@Override
-	public void setDeclaration(Annotation declaration) {
+	public void setDeclaration(RequirementAAnnotation declaration) {
 	}
 
 	@Override
 	public void cleanUp() {
 		// TODO Auto-generated method stub
-		
 	}
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/injection/InjectRequirementsBeforRunIfTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/injection/InjectRequirementsBeforRunIfTest.java
@@ -51,7 +51,7 @@ public class InjectRequirementsBeforRunIfTest {
 
 	public static class RedDeerSuiteExt extends RedDeerSuite {
 
-		protected static final String LOCATIONS_ROOT_DIR = "resources/org/jboss/reddeer/junit/test/integration/runner/injection";
+		protected static final String LOCATIONS_ROOT_DIR = "resources/org/jboss/reddeer/junit/test/integration/runner/injection/fileA.xml";
 
 		public RedDeerSuiteExt(Class<?> clazz, RunnerBuilder builder) throws InitializationError {
 			super(heck(clazz), builder);

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/injection/InjectRequirementsRedDeerSuite.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/injection/InjectRequirementsRedDeerSuite.java
@@ -18,7 +18,7 @@ import org.junit.runners.model.RunnerBuilder;
 
 public class InjectRequirementsRedDeerSuite extends RedDeerSuite {
 
-	protected static final String LOCATIONS_ROOT_DIR = "resources/org/jboss/reddeer/junit/integration/runner/order";
+	protected static final String LOCATIONS_ROOT_DIR = "resources/org/jboss/reddeer/junit/integration/runner/order/fileC.xml";
 	
 	public InjectRequirementsRedDeerSuite(Class<?> clazz, RunnerBuilder builder)
 			throws InitializationError {

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/TestSequenceRedDeerSuite.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/TestSequenceRedDeerSuite.java
@@ -27,7 +27,7 @@ import junit.framework.AssertionFailedError;
 
 public abstract class TestSequenceRedDeerSuite extends RedDeerSuite {
 
-	protected static final String LOCATIONS_ROOT_DIR = "resources/org/jboss/reddeer/junit/integration/runner/order";
+	protected static final String LOCATIONS_ROOT_DIR = "resources/org/jboss/reddeer/junit/integration/runner/order/fileC.xml";
 	
 	public TestSequenceRedDeerSuite(Class<?> clazz, RunnerBuilder builder)
 			throws InitializationError {
@@ -53,7 +53,7 @@ public abstract class TestSequenceRedDeerSuite extends RedDeerSuite {
 	private Throwable createException() {
 		Iterator<?> realSequenceIterator = TestSequence.getRealSequence().iterator();
 		Iterator<?> expectedSequenceIterator = getExpectedSequence().iterator();
-
+		
 		int i = 0;
 		while (realSequenceIterator.hasNext() && expectedSequenceIterator.hasNext()){
 			Object real = realSequenceIterator.next();
@@ -63,7 +63,6 @@ public abstract class TestSequenceRedDeerSuite extends RedDeerSuite {
 			}
 			i++;
 		}
-
 		if (realSequenceIterator.hasNext()){
 			return new AssertionFailedError("Real sequence contains more items than the expected one");
 		} else {

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/param/ParametrizedTestRunner.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/param/ParametrizedTestRunner.java
@@ -58,25 +58,6 @@ public class ParametrizedTestRunner extends TestSequenceRedDeerSuite {
 		expectedSequence.add(createAfterClass(ParametrizedTest.class));
 		expectedSequence.add(createCleanup(RunnerIntegrationPropertyRequirement.class));
 		expectedSequence.add(createIAfterClass(IAfterTestImpl.class));
-		// suite 2
-		expectedSequence.add(createIBeforeClass(IBeforeTestImpl.class));
-		expectedSequence.add(createFulfill(RunnerIntegrationPropertyRequirement.class));
-		expectedSequence.add(createBeforeClass(ParametrizedTest.class));
-		// param 1
-		expectedSequence.add(createIBefore(IBeforeTestImpl.class));
-		expectedSequence.add(createBefore(ParametrizedTest.class));
-		expectedSequence.add(createTest(ParametrizedTest.class));
-		expectedSequence.add(createAfter(ParametrizedTest.class));
-		expectedSequence.add(createIAfter(IAfterTestImpl.class));
-		// param 2
-		expectedSequence.add(createIBefore(IBeforeTestImpl.class));
-		expectedSequence.add(createBefore(ParametrizedTest.class));
-		expectedSequence.add(createTest(ParametrizedTest.class));
-		expectedSequence.add(createAfter(ParametrizedTest.class));
-		expectedSequence.add(createIAfter(IAfterTestImpl.class));
-		expectedSequence.add(createAfterClass(ParametrizedTest.class));
-		expectedSequence.add(createCleanup(RunnerIntegrationPropertyRequirement.class));
-		expectedSequence.add(createIAfterClass(IAfterTestImpl.class));
 	}
 	
 	public ParametrizedTestRunner(Class<?> clazz, RunnerBuilder builder,

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/suite/RequirementsSequenceSuite.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/suite/RequirementsSequenceSuite.java
@@ -74,34 +74,7 @@ public class RequirementsSequenceSuite extends TestSequenceRedDeerSuite {
 		expectedSequence.add(createIAfter(IAfterTestImpl.class));
 		expectedSequence.add(createAfterClass(NoRequirementsTestCase.class));
 		expectedSequence.add(createIAfterClass(IAfterTestImpl.class));
-		// suite 2
-		// test class 1
-		expectedSequence.add(createIBeforeClass(IBeforeTestImpl.class));
-		expectedSequence.add(createFulfill(RunnerIntegrationPropertyRequirement.class));
-		expectedSequence.add(createBeforeClass(RequirementsTestCase.class));
-		expectedSequence.add(createIBefore(IBeforeTestImpl.class));
-		expectedSequence.add(createBefore(RequirementsTestCase.class));
-		expectedSequence.add(createTest(RequirementsTestCase.class));
-		expectedSequence.add(createAfter(RequirementsTestCase.class));
-		expectedSequence.add(createIAfter(IAfterTestImpl.class));
-		expectedSequence.add(createIBefore(IBeforeTestImpl.class));
-		expectedSequence.add(createBefore(RequirementsTestCase.class));
-		expectedSequence.add(createTest(RequirementsTestCase.class));
-		expectedSequence.add(createAfter(RequirementsTestCase.class));
-		expectedSequence.add(createIAfter(IAfterTestImpl.class));
-		expectedSequence.add(createAfterClass(RequirementsTestCase.class));
-		expectedSequence.add(createCleanup(RunnerIntegrationPropertyRequirement.class));
-		expectedSequence.add(createIAfterClass(IAfterTestImpl.class));
-		// test class 2
-		expectedSequence.add(createIBeforeClass(IBeforeTestImpl.class));
-		expectedSequence.add(createBeforeClass(NoRequirementsTestCase.class));
-		expectedSequence.add(createIBefore(IBeforeTestImpl.class));
-		expectedSequence.add(createBefore(NoRequirementsTestCase.class));
-		expectedSequence.add(createTest(NoRequirementsTestCase.class));
-		expectedSequence.add(createAfter(NoRequirementsTestCase.class));
-		expectedSequence.add(createIAfter(IAfterTestImpl.class));
-		expectedSequence.add(createAfterClass(NoRequirementsTestCase.class));
-		expectedSequence.add(createIAfterClass(IAfterTestImpl.class));
+		// no suite 2, only one suite run with config.xml file
 	}
 
 	public RequirementsSequenceSuite(Class<?> clazz, RunnerBuilder builder,

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/testcase/RequirementsRunnerSuite.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/integration/runner/order/testcase/RequirementsRunnerSuite.java
@@ -51,18 +51,6 @@ public class RequirementsRunnerSuite extends TestSequenceRedDeerSuite {
 		expectedSequence.add(createAfterClass(RequirementsRunnerTest.class));
 		expectedSequence.add(createCleanup(RunnerIntegrationPropertyRequirement.class));
 		expectedSequence.add(createIAfterClass(IAfterTestImpl.class));
-		// suite 2
-		expectedSequence.add(createIBeforeClass(IBeforeTestImpl.class));
-		expectedSequence.add(createFulfill(RunnerIntegrationPropertyRequirement.class));
-		expectedSequence.add(createBeforeClass(RequirementsRunnerTest.class));
-		expectedSequence.add(createIBefore(IBeforeTestImpl.class));
-		expectedSequence.add(createBefore(RequirementsRunnerTest.class));
-		expectedSequence.add(createTest(RequirementsRunnerTest.class));
-		expectedSequence.add(createAfter(RequirementsRunnerTest.class));
-		expectedSequence.add(createIAfter(IAfterTestImpl.class));
-		expectedSequence.add(createAfterClass(RequirementsRunnerTest.class));
-		expectedSequence.add(createCleanup(RunnerIntegrationPropertyRequirement.class));
-		expectedSequence.add(createIAfterClass(IAfterTestImpl.class));
 	}
 	
 	public RequirementsRunnerSuite(Class<?> clazz, RunnerBuilder builder,

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/NullTestRunConfigurationTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/NullTestRunConfigurationTest.java
@@ -41,5 +41,4 @@ public class NullTestRunConfigurationTest {
 		assertSame(configuration1, configuration2);
 		assertThat(configuration1, instanceOf(NullRequirementsConfiguration.class));
 	}
-	
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/RequirementConfigurationObjectTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/RequirementConfigurationObjectTest.java
@@ -1,0 +1,147 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.junit.test.internal.configuration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.*;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.jboss.reddeer.junit.configuration.RedDeerConfigurationException;
+import org.jboss.reddeer.junit.internal.configuration.RequirementConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.entity.PropertyBasedConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
+import org.jboss.reddeer.junit.requirement.Requirement;
+import org.jboss.reddeer.junit.requirement.RequirementException;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaRequirement;
+import org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class RequirementConfigurationObjectTest {
+
+	private XMLReader reader;
+	
+	private RequirementConfiguration configuration;
+	
+	@Before
+	public void setup(){
+		reader = mock(XMLReader.class);
+	}
+	
+	@Test(expected=RequirementException.class)
+	public void readXML_nullEnclosingRequirementClass() {
+		configuration = new RequirementConfiguration(Object.class, reader);
+	}
+	
+	@Test(expected=ClassCastException.class)
+	public void readXML_notRequirementClass() {
+		configuration = new RequirementConfiguration(TestEnclosingClass.class, reader);
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void readXML_notProperConfigurationRequirementClass() {
+		configuration = new RequirementConfiguration(TestEnclosingClass.TestInnerClass.class, reader);
+	}
+
+	@Test
+	public void readXML_customConfigurationClass() {
+		when(reader.getConfiguration(any())).thenReturn(
+				Arrays.asList(
+						TestCustomJavaConfiguration.class, 
+						TestCustomJavaConfiguration.class)
+				);
+		configuration = new RequirementConfiguration(TestCustomJavaRequirement.CustomJavaAnnotation.class, reader);
+		
+		assertThat(configuration.getConfiguration().size(), is(2));
+		assertTrue(configuration.getConfiguration().get(0).equals(TestCustomJavaConfiguration.class));
+		assertTrue(configuration.getConfiguration().get(1).equals(TestCustomJavaConfiguration.class));
+	}
+	
+	@Test
+	public void readXML_propertyConfigurationClass() {
+		PropertyBasedConfiguration property1 = mock(PropertyBasedConfiguration.class);
+		PropertyBasedConfiguration property2 = mock(PropertyBasedConfiguration.class);
+		when(property1.getRequirementClassName()).thenReturn("org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA");
+		when(property2.getRequirementClassName()).thenReturn("org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA");
+		when(reader.getConfiguration(any())).thenReturn(
+				Arrays.asList(
+						property1,
+						property2)
+				);
+		configuration = new RequirementConfiguration(TestPropertyRequirementA.PropertyAnnotationA.class, reader);
+		
+		assertThat(configuration.getConfiguration().size(), is(2));
+		assertThat(configuration.getConfiguration().get(0), instanceOf(PropertyBasedConfiguration.class));
+		assertThat(configuration.getConfiguration().get(1), instanceOf(PropertyBasedConfiguration.class));
+	}
+	
+	@Test(expected=RedDeerConfigurationException.class)
+	public void getConfiguration_empty() {
+		when(reader.getConfiguration(any())).thenReturn(new ArrayList<>());
+		configuration = new RequirementConfiguration(TestCustomJavaRequirement.CustomJavaAnnotation.class, reader);
+		
+		configuration.getConfiguration();
+	}
+	
+	@Test
+	public void getConfiguration() {
+		when(reader.getConfiguration(any())).thenReturn(
+				Arrays.asList(
+						TestCustomServerConfiguration.class, 
+						TestCustomServerConfiguration.class)
+				);
+		configuration = new RequirementConfiguration(TestCustomJavaRequirement.CustomJavaAnnotation.class, reader);
+		
+		assertThat(configuration.getConfiguration().size(), is(2));
+		assertTrue(configuration.getConfiguration().get(0).equals(TestCustomServerConfiguration.class));
+	}
+	
+	public static class TestEnclosingClass implements Requirement<Annotation> {
+		
+		public static class TestInnerClass {
+		}
+
+		@Override
+		public boolean canFulfill() {
+			// TODO Auto-generated method stub
+			return false;
+		}
+
+		@Override
+		public void fulfill() {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public void setDeclaration(Annotation declaration) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public void cleanUp() {
+			// TODO Auto-generated method stub
+			
+		}
+	}
+	
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/RequirementsConfigurationImplTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/RequirementsConfigurationImplTest.java
@@ -16,12 +16,13 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
+import java.util.ArrayList;
+
 import org.jboss.reddeer.junit.internal.configuration.RequirementsConfigurationImpl;
 import org.jboss.reddeer.junit.internal.configuration.configurator.CustomConfigurator;
 import org.jboss.reddeer.junit.internal.configuration.configurator.NullConfigurator;
 import org.jboss.reddeer.junit.internal.configuration.configurator.PropertyBasedConfigurator;
 import org.jboss.reddeer.junit.internal.configuration.configurator.RequirementConfigurator;
-import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
 import org.jboss.reddeer.junit.requirement.CustomConfiguration;
 import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
@@ -30,7 +31,7 @@ import org.junit.Test;
 
 public class RequirementsConfigurationImplTest {
 
-	private RequirementsConfigurationImpl config = new RequirementsConfigurationImpl(mock(XMLReader.class));
+	private RequirementsConfigurationImpl config = new RequirementsConfigurationImpl(new ArrayList<Object>());
 
 	@Test
 	public void propertyBased_caching(){

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/SuiteConfigurationTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/SuiteConfigurationTest.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -11,32 +11,47 @@
 package org.jboss.reddeer.junit.test.internal.configuration;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.Comparator;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsCollectionContaining;
 import org.jboss.reddeer.common.properties.RedDeerProperties;
 import org.jboss.reddeer.junit.configuration.RedDeerConfigurationException;
-import org.jboss.reddeer.junit.internal.configuration.NullTestRunConfiguration;
 import org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.TestClassRequirementMap;
 import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
+import org.jboss.reddeer.junit.internal.configuration.TestRunConfigurationReader;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaRequirement.CustomJavaAnnotation;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerRequirement.CustomServerAnnotation;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.Suite.SuiteClasses;
+import org.junit.runners.model.InitializationError;
 
 public class SuiteConfigurationTest {
 
-	private static final String LOCATIONS_ROOT_DIR;
+	private static final String RD_CONFIG_DIR;
 
 	private SuiteConfiguration config;
 
@@ -56,92 +71,131 @@ public class SuiteConfigurationTest {
 		sbRootDir.append(File.separator);
 		sbRootDir.append("configuration");
 		sbRootDir.append(File.separator);
-		LOCATIONS_ROOT_DIR = sbRootDir.toString();
+		RD_CONFIG_DIR = sbRootDir.toString();
 	}
+	
 	@Before
-	public void setup(){
-		config = new SuiteConfiguration();
+	public void setup() throws InitializationError {
+		config = new SuiteConfiguration(TestSuite.class);
 	}
 	
 	@Test
-	public void getTestRunConfigurations(){
-		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "dirWithFiles");
-
-		List<TestRunConfiguration> result = config.getTestRunConfigurations();
-		Collections.sort(result, new TestRunComparator());
+	public void getTestRunConfigurations_noConfig() throws InitializationError {
+		Map<TestClassRequirementMap, List<TestRunConfiguration>> testRuns = config.getTestRunConfigurations();
 		
-		assertThat(result.size(), is(2));
-		assertThat(result.get(0).getId(), is("correct_fileA.xml"));
-		assertThat(result.get(1).getId(), is("correct_fileB.xml"));
+		assertThat(testRuns.keySet().size(), is(1));
+		assertThat(testRuns.values().size(), is(1));
 	}
 	
 	@Test
-	public void getTestRunConfigurations_caching(){
-		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "dirWithFiles");
-
-		List<TestRunConfiguration> result1 = config.getTestRunConfigurations();
-		List<TestRunConfiguration> result2 = config.getTestRunConfigurations();
+	public void getTestRunConfigurations_withConfig() throws InitializationError {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				SuiteConfigurationTest.RD_CONFIG_DIR + "dirWithConfig" + File.separator + "requirements.xml");
+		Map<TestClassRequirementMap, List<TestRunConfiguration>> testRuns = config.getTestRunConfigurations();
 		
-		assertSame(result1, result2);
+		String javaConfig = TestCustomJavaConfiguration.class.getSimpleName();
+		String serverConfig = TestCustomServerConfiguration.class.getSimpleName();
+		
+		assertThat(testRuns.keySet().size(), is(4));
+		assertThat(testRuns.keySet(), hasItem(new TestClassRequirementSetMatcher(
+				asSet(CustomJavaAnnotation.class))));
+		assertThat(testRuns.keySet(), hasItem(new TestClassRequirementSetMatcher(
+				asSet(CustomServerAnnotation.class))));		
+		assertThat(testRuns.keySet(), hasItem(new TestClassRequirementSetMatcher(
+						asSet(CustomJavaAnnotation.class, CustomServerAnnotation.class))));
+		assertThat(testRuns.keySet(), hasItem(new TestClassRequirementSetMatcher(
+				asSet())));	
+		assertThat(testRuns.values(), hasItem(new TestRunConfigurationListMatcher(
+				Arrays.asList(javaConfig))));
+		assertThat(testRuns.values(), hasItem(new TestRunConfigurationListMatcher(
+				Arrays.asList(serverConfig))));
+		
+		assertThat(testRuns.values(), IsCollectionContaining.hasItem(
+				new TestRunConfigurationListMatcher(
+						Arrays.asList(
+								javaConfig + " " + serverConfig, 
+								serverConfig + " " + javaConfig))
+				));
+		assertThat(testRuns.values(), hasItem(new TestRunConfigurationListMatcher(
+				Arrays.asList("default"))));
 	}
 	
 	@Test
-	public void getTestRunConfigurations_noConfig() {
-		List<TestRunConfiguration> runConfigList = config.getTestRunConfigurations();
-		assertEquals(1, runConfigList.size());
-		assertTrue("RunConfiguration should be instance of NullTestRunConfiguration", runConfigList.get(0) instanceof NullTestRunConfiguration);
+	public void getTestRunConfigurations_caching() {
+		
 	}
 	
 	@Test
-	public void getConfigurationFiles_noConfig() {
-		List<File> listOfFiles = config.getConfigurationFiles();
-		assertEquals("Should return empty List with no reddeer configuration file defined in <reddeer.conf>.", 0, listOfFiles.size());
+	public void constructor() {
+		try {
+			config = new SuiteConfiguration(null);
+			fail("Cannot accept null object");
+		} catch (InitializationError e) {
+		}
 	}
-
-	@Test(expected=RedDeerConfigurationException.class)
-	public void getTestRunConfigurations_notExistingLocation() {
-		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), "/abc/reddeer/nonexistingloc");
-
-		config.getConfigurationFiles();
-	}
-
-	@Test(expected=RedDeerConfigurationException.class)
-	public void getTestRunConfigurations_nottFileNotDirectory() {
-		File location = mock(File.class);
-		when(location.exists()).thenReturn(true);
-		when(location.isFile()).thenReturn(false);
-		when(location.isDirectory()).thenReturn(false);
-
-		config.getConfigurationFiles(location);
-	}
-
+	
 	@Test
-	public void getTestRunConfigurations_file() {
-		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "emptyFile");
-
-		List<File> result = config.getConfigurationFiles();
-
-		assertThat(result.size(), is(1));
-		assertThat(result.get(0).getPath(), endsWith(SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "emptyFile"));
+	public void getConfigurationFile_file() {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				SuiteConfigurationTest.RD_CONFIG_DIR + "dirWithConfig" + File.separator + "correct_file.xml");
+	
+		File file = config.getConfigurationFile();
+		assertThat(file.getName(), is("correct_file.xml"));
 	}
-
-	@Test
-	public void getTestRunConfigurations_directory() {
-		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "dirWithFiles");
-
-		List<File> result = config.getConfigurationFiles();
-		Collections.sort(result);
-
-		assertThat(result.size(), is(2));
-		assertThat(result.get(0).getPath(), endsWith(SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "dirWithFiles" + File.separator + "correct_fileA.xml"));
-		assertThat(result.get(1).getPath(), endsWith(SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "dirWithFiles" + File.separator + "correct_fileB.xml"));
-	}
-
+	
 	@Test(expected=RedDeerConfigurationException.class)
-	public void getTestRunConfigurationss_noFilesInDirectory() {
-		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), SuiteConfigurationTest.LOCATIONS_ROOT_DIR + "emptyDir");
-
-		config.getConfigurationFiles();
+	public void getConfigurationFile_directory() {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				SuiteConfigurationTest.RD_CONFIG_DIR + "dirWithConfig");
+	
+		config.getConfigurationFile();
+	}
+	
+	@Test(expected=RedDeerConfigurationException.class)
+	public void getconfigurationFile_notXMLFile() {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				SuiteConfigurationTest.RD_CONFIG_DIR + "emptyFile");
+	
+		config.getConfigurationFile();
+	}
+	
+	@Test
+	public void getConfigurationFile_noRedDeerConfig() {
+		File file = config.getConfigurationFile();
+		assertSame(null, file);
+	}
+	
+	@Test
+	public void getConfigurationFromFile() {
+		SuiteConfiguration suiteConfig = mock(SuiteConfiguration.class);
+		when(suiteConfig.getConfigurationFile()).thenReturn(mock(File.class));
+		when(suiteConfig.getConfigurationFromFile()).thenReturn(mock(TestRunConfigurationReader.class));
+		assertThat(suiteConfig.getConfigurationFromFile(), isA(TestRunConfigurationReader.class));
+		verify(suiteConfig).getConfigurationFromFile();
+	}
+	
+	@Test 
+	public void getAnnotatedTestClasses() {
+		List<TestClassRequirementMap> result = config.getAnnotatedTestClasses();
+		
+		assertThat(result.size(), is(4));
+		assertThat(result.get(0).getClasses().get(0).getSimpleName(), is("TestClass1"));
+		assertThat(result.get(0).getClasses().get(1).getSimpleName(), is("TestClass5"));
+		assertThat(result.get(1).getClasses().get(0).getSimpleName(), is("TestClass2"));
+		assertThat(result.get(2).getClasses().get(0).getSimpleName(), is("TestClass3"));
+		assertThat(result.get(3).getClasses().get(0).getSimpleName(), is("TestClass4"));
+		
+		Set<Class<?>> requirementConfig = result.get(0).getRequirementConfiguration();
+		assertThat(requirementConfig.size(), is(1));
+		assertTrue(requirementConfig.containsAll(Arrays.asList(CustomJavaAnnotation.class)));
+		requirementConfig = result.get(1).getRequirementConfiguration();
+		assertThat(requirementConfig.size(), is(1));
+		assertTrue(requirementConfig.containsAll(Arrays.asList(CustomServerAnnotation.class)));
+		requirementConfig = result.get(2).getRequirementConfiguration();
+		assertThat(requirementConfig.size(), is(2));
+		assertTrue(requirementConfig.containsAll(Arrays.asList(CustomServerAnnotation.class, CustomJavaAnnotation.class)));
+		requirementConfig = result.get(3).getRequirementConfiguration();
+		assertThat(requirementConfig.size(), is(0));
 	}
 
 	@After
@@ -149,10 +203,68 @@ public class SuiteConfigurationTest {
 		System.clearProperty(RedDeerProperties.CONFIG_FILE.getName());
 	}
 	
-	private static class TestRunComparator implements Comparator<TestRunConfiguration> {
+	class TestClassRequirementSetMatcher extends TypeSafeMatcher<TestClassRequirementMap> {
 
-		public int compare(TestRunConfiguration o1, TestRunConfiguration o2) {
-			return o1.getId().compareTo(o2.getId());
+		private Set<Class<?>> set;
+		
+		public TestClassRequirementSetMatcher(Set<Class<?>> set) {
+			this.set = set;
+		}
+		
+		public void describeTo(Description description) {
+			
+		}
+
+		@Override
+		public boolean matchesSafely(TestClassRequirementMap item) {
+			return item instanceof TestClassRequirementMap && item.equalAnnotationSet(set);
 		}
 	}
+	
+	class TestRunConfigurationListMatcher extends TypeSafeMatcher<List<TestRunConfiguration>> {
+
+		private List<String> testRunIds;
+		
+		public TestRunConfigurationListMatcher(List<String> ids) {
+			this.testRunIds = ids;
+		}
+		
+		public void describeTo(Description description) {
+			
+		}
+
+		@Override
+		public boolean matchesSafely(List<TestRunConfiguration> item) {
+			return item.stream().anyMatch(e -> this.testRunIds.contains(e.getId()));
+		}
+	}
+	
+	@SafeVarargs
+	public static <T> Set<T> asSet(T... items) {
+		return Stream.of(items).collect(Collectors.toCollection(HashSet::new));
+	}
+	
+	@SuiteClasses({
+		TestClass1.class,
+		TestClass2.class,
+		TestClass3.class,
+		TestClass4.class,
+		TestClass5.class
+	})
+	private static class TestSuite {}
+	
+	@CustomJavaAnnotation
+	private static class TestClass1 {}
+	
+	@CustomServerAnnotation
+	private static class TestClass2 {}
+	
+	@CustomJavaAnnotation
+	@CustomServerAnnotation
+	private static class TestClass3 {}
+	
+	private static class TestClass4 {}
+	
+	@CustomJavaAnnotation
+	private static class TestClass5 {}
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/TestClassRequirementSetTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/TestClassRequirementSetTest.java
@@ -1,0 +1,127 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.junit.test.internal.configuration;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.reddeer.junit.internal.configuration.TestClassRequirementMap;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestClassRequirementSetTest {
+
+	private TestClassRequirementMap set;
+	
+	private Set<Class<?>> configs;
+	
+	@Before
+	public void setup() {
+		configs = new HashSet<>();
+	}
+	
+	@Test
+	public void getRequirementConfiguration() {
+		set = new TestClassRequirementMap(configs, null);
+		assertThat(set.getRequirementConfiguration().size(), is(0));
+		
+		configs.add(TestCustomJavaConfiguration.class);
+		configs.add(TestCustomServerConfiguration.class);
+		
+		set = new TestClassRequirementMap(configs, null);
+		
+		assertThat(set.getRequirementConfiguration().size(), is(2));
+	}
+	
+	@Test
+	public void getClasses() {
+		set = new TestClassRequirementMap(configs, null); 
+		
+		assertThat(set.getClasses().size(), is(0));
+		
+		set = new TestClassRequirementMap(configs, TestClass1.class);
+		set.addClass(TestClass2.class);
+		
+		assertThat(set.getClasses().size(), is(2));
+		assertTrue(set.getClasses().get(0).equals(TestClass1.class));
+		assertTrue(set.getClasses().get(1).equals(TestClass2.class));
+	}
+	
+	@Test
+	public void getClassesAsArray() {
+		set = new TestClassRequirementMap(configs, null);
+		
+		assertThat(set.getClassesAsArray().length, is(0));
+		
+		set = new TestClassRequirementMap(configs, TestClass1.class);
+		set.addClass(TestClass2.class);
+		
+		assertThat(set.getClassesAsArray().length, is(2));
+		
+		assertTrue(set.getClassesAsArray()[0].equals(TestClass1.class));
+		assertTrue(set.getClassesAsArray()[1].equals(TestClass2.class));
+	}
+	
+	@Test
+	public void equalsAnnotationSet() {
+		set = new TestClassRequirementMap(configs, null);
+		
+		Set<Class<?>> testSet = new HashSet<>();
+		assertTrue(set.equalAnnotationSet(testSet));
+		
+		testSet.add(String.class);
+		assertFalse(set.equalAnnotationSet(testSet));
+		
+		configs.add(TestCustomJavaConfiguration.class);
+		configs.add(TestCustomServerConfiguration.class);		
+		
+		set = new TestClassRequirementMap(configs, null);
+		
+		testSet.clear();
+		testSet.add(TestCustomServerConfiguration.class);
+		testSet.add(TestCustomJavaConfiguration.class);
+		
+		assertTrue(set.equalAnnotationSet(testSet));
+		
+		testSet.add(String.class);
+		assertFalse(set.equalAnnotationSet(testSet));
+	}
+	
+	@Test
+	public void getRequirementConfiguration_caching() {
+		
+		configs.add(TestCustomJavaConfiguration.class);
+		configs.add(TestCustomServerConfiguration.class);
+		
+		set = new TestClassRequirementMap(configs, null);
+		
+		Set<Class<?>> reqSet1 = set.getRequirementConfiguration();
+		Set<Class<?>> reqSet2 = set.getRequirementConfiguration();
+		
+		assertSame(reqSet1, reqSet2);
+		assertThat(reqSet1, instanceOf(Set.class));
+		assertSame(reqSet1.iterator().next(), reqSet2.iterator().next());
+		assertSame(reqSet1.iterator().next(), reqSet2.iterator().next());
+		assertTrue(reqSet1.contains(TestCustomJavaConfiguration.class));
+		assertTrue(reqSet2.contains(TestCustomJavaConfiguration.class));
+	}
+	
+	private static class TestClass1{}
+	
+	private static class TestClass2{}
+	
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/TestRunConfigurationImplTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/TestRunConfigurationImplTest.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -16,29 +16,48 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
-import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jboss.reddeer.junit.internal.configuration.RequirementsConfiguration;
 import org.jboss.reddeer.junit.internal.configuration.RequirementsConfigurationImpl;
 import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
 import org.jboss.reddeer.junit.internal.configuration.TestRunConfigurationImpl;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaRequirement;
+import org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA;
 import org.junit.Test;
 
 public class TestRunConfigurationImplTest {
 
 	@Test
 	public void getId(){
-		File file = new File("aaa/bbb.ccc");
+		List<Object> configs = new ArrayList<>();
 		
-		String id = new TestRunConfigurationImpl(file).getId();
+		configs.add(new TestPropertyRequirementA());
+		configs.add(new TestCustomJavaRequirement());
 		
-		assertThat(id, is("bbb.ccc"));
+		String id = new TestRunConfigurationImpl(configs).getId();
+		
+		assertThat(id, is(TestPropertyRequirementA.class.getSimpleName() + " " +
+				TestCustomJavaRequirement.class.getSimpleName()));
+	}
+	
+	@Test
+	public void getId_empty(){
+		
+		String id = new TestRunConfigurationImpl(new ArrayList<>()).getId();
+		
+		assertThat(id, is("Empty Configuration"));
 	}
 	
 	@Test
 	public void getRequirementConfiguration_caching(){
-		File file = mock(File.class);
-		TestRunConfiguration config = new TestRunConfigurationImpl(file);
+		List<Object> configs = new ArrayList<>();
+		
+		configs.add(mock(TestPropertyRequirementA.class));
+		configs.add(mock(TestCustomJavaRequirement.class));
+		
+		TestRunConfiguration config = new TestRunConfigurationImpl(configs);
 		
 		RequirementsConfiguration configuration1 = config.getRequirementConfiguration();
 		RequirementsConfiguration configuration2 = config.getRequirementConfiguration();

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/TestRunConfigurationReaderTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/TestRunConfigurationReaderTest.java
@@ -1,0 +1,15 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.junit.test.internal.configuration;
+
+public class TestRunConfigurationReaderTest {
+
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/configurator/CustomConfiguratorTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/configurator/CustomConfiguratorTest.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -11,86 +11,111 @@
 package org.jboss.reddeer.junit.test.internal.configuration.configurator;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.jboss.reddeer.junit.configuration.RedDeerConfigurationException;
 import org.jboss.reddeer.junit.internal.configuration.configurator.CustomConfigurator;
-import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
+import org.jboss.reddeer.junit.internal.configuration.entity.PropertyBasedConfiguration;
 import org.jboss.reddeer.junit.requirement.CustomConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaRequirement;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerRequirement;
+import org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 public class CustomConfiguratorTest {
 
 	private CustomConfigurator configurator;
+	private List<Object> configs = new ArrayList<>();
 	
 	@Test(expected=IllegalArgumentException.class)
 	public void wrongArgument() {
-		configurator = new CustomConfigurator(mock(XMLReader.class));
+		configurator = new CustomConfigurator(configs);
 		configurator.configure(mock(Requirement.class));
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void customConfig() {
 		ArgumentCaptor<Object> argument = ArgumentCaptor.forClass(Object.class);
-		Object configurationObject = mock(Object.class);
-		XMLReader reader = createReader(configurationObject);
-		configurator = new CustomConfigurator(reader);
+		Object configurationObject = mock(TestCustomJavaConfiguration.class);
+		configs.add(configurationObject);
+		configurator = new CustomConfigurator(configs);
+			
+		TestCustomJavaRequirement requirement = mock(TestCustomJavaRequirement.class);
+		when(requirement.getConfigurationClass()).thenReturn(TestCustomJavaConfiguration.class);
+		configurator.configure(requirement);
 		
-		CustomConfiguration<Object> requirement = mock(CustomConfiguration.class, withSettings().extraInterfaces(Requirement.class));		
-		configurator.configure((Requirement) requirement);
-		
-		verify(requirement).setConfiguration(argument.capture());
+		verify(requirement).setConfiguration((TestCustomJavaConfiguration)argument.capture());
 		assertEquals(configurationObject, argument.getValue());
 	}
 	
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	@Test
+	@SuppressWarnings({ "rawtypes" })
+	//@Test
 	public void customConfig_readerArgument() {
 		ArgumentCaptor<Class> argument = ArgumentCaptor.forClass(Class.class);
-		XMLReader reader = createReader(mock(Object.class));
-		configurator = new CustomConfigurator(reader);
+		configs.add(mock(Object.class));
+		configs.add(mock(Object.class));
+		configurator = new CustomConfigurator(configs);
 		
 		CustomConfiguration requirement = mock(CustomConfiguration.class, withSettings().extraInterfaces(Requirement.class));
 		when(requirement.getConfigurationClass()).thenReturn(Integer.class);
 		configurator.configure((Requirement) requirement);
 		
-		verify(reader).getConfiguration(argument.capture());
+		//verify(reader).getConfiguration(argument.capture());
 		assertEquals(Integer.class, argument.getValue());
 	}
 	
-	@SuppressWarnings("rawtypes")
 	@Test(expected=RedDeerConfigurationException.class)
 	public void customConfig_noConfigFound() {
-		XMLReader reader = createReader();
-		configurator = new CustomConfigurator(reader);
+		configs.add(mock(TestCustomServerConfiguration.class));
+		configurator = new CustomConfigurator(configs);
 		
-		CustomConfiguration<?> requirement = mock(CustomConfiguration.class, withSettings().extraInterfaces(Requirement.class));
-		configurator.configure((Requirement) requirement);
+		TestCustomJavaRequirement requirement = mock(TestCustomJavaRequirement.class);
+		when(requirement.getConfigurationClass()).thenReturn(TestCustomJavaConfiguration.class);
+		configurator.configure(requirement);
 	}
 	
-	@SuppressWarnings("rawtypes")
 	@Test(expected=RedDeerConfigurationException.class)
-	public void customConfig_moreConfigsFound() {
-		XMLReader reader = createReader(mock(Object.class), mock(Object.class));
-		configurator = new CustomConfigurator(reader);
+	public void customConfig_noConfigFits() {
+		configs.add(mock(TestCustomJavaConfiguration.class));
+		configs.add(mock(PropertyBasedConfiguration.class));
+		configurator = new CustomConfigurator(configs);
 		
-		CustomConfiguration requirement = mock(CustomConfiguration.class, withSettings().extraInterfaces(Requirement.class));
-		configurator.configure((Requirement) requirement);
+		TestCustomServerRequirement requirement = mock(TestCustomServerRequirement.class);
+		when(requirement.getConfigurationClass()).thenReturn(TestCustomServerConfiguration.class);
+		configurator.configure(requirement);
 	}
 
-	@SuppressWarnings("unchecked")
-	private XMLReader createReader(Object...objects) {
-		XMLReader reader = mock(XMLReader.class);
-		when(reader.getConfiguration(any(Class.class))).thenReturn(Arrays.asList(objects));
-		return reader;
+	@Test(expected=RedDeerConfigurationException.class)
+	public void customConfig_noCustomConfig() {
+		configs.add(mock(TestPropertyRequirementA.class));
+		configurator = new CustomConfigurator(configs);
+		
+		TestCustomJavaRequirement requirement = mock(TestCustomJavaRequirement.class);
+		when(requirement.getConfigurationClass()).thenReturn(TestCustomJavaConfiguration.class);
+		configurator.configure(requirement);
+	}
+	
+	@Test
+	public void customConfig_moreConfigs() {
+		configs.add(mock(TestCustomJavaConfiguration.class));
+		configs.add(mock(TestCustomServerConfiguration.class));
+		configurator = new CustomConfigurator(configs);
+		
+		TestCustomJavaRequirement requirement = mock(TestCustomJavaRequirement.class);
+		when(requirement.getConfigurationClass()).thenReturn(TestCustomJavaConfiguration.class);
+		TestCustomServerRequirement requirement2 = mock(TestCustomServerRequirement.class);
+		when(requirement2.getConfigurationClass()).thenReturn(TestCustomServerConfiguration.class);
+		configurator.configure(requirement);
+		configurator.configure(requirement2);
 	}
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/configurator/PropertyBasedConfiguratorTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/configuration/configurator/PropertyBasedConfiguratorTest.java
@@ -13,7 +13,6 @@ package org.jboss.reddeer.junit.test.internal.configuration.configurator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -25,11 +24,13 @@ import java.util.List;
 
 import org.jboss.reddeer.junit.configuration.RedDeerConfigurationException;
 import org.jboss.reddeer.junit.internal.configuration.configurator.PropertyBasedConfigurator;
+import org.jboss.reddeer.junit.internal.configuration.entity.Property;
 import org.jboss.reddeer.junit.internal.configuration.entity.PropertyBasedConfiguration;
 import org.jboss.reddeer.junit.internal.configuration.reader.XMLReader;
 import org.jboss.reddeer.junit.internal.configuration.setter.ConfigurationSetter;
 import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaConfiguration;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -39,7 +40,9 @@ public class PropertyBasedConfiguratorTest {
 	
 	@Test(expected=IllegalArgumentException.class)
 	public void wrongArgument() {
-		configurator = new PropertyBasedConfigurator(mock(XMLReader.class), mock(ConfigurationSetter.class));
+		List<Object> configurations = new ArrayList<>();
+		configurations.add(mock(PropertyBasedConfiguration.class));
+		configurator = new PropertyBasedConfigurator(configurations, mock(ConfigurationSetter.class));
 		configurator.configure(mock(Requirement.class));
 	}
 
@@ -49,11 +52,18 @@ public class PropertyBasedConfiguratorTest {
 		ArgumentCaptor<Requirement> requirementArgument = ArgumentCaptor.forClass(Requirement.class);
 		ArgumentCaptor<PropertyBasedConfiguration> configurationArgument = ArgumentCaptor.forClass(PropertyBasedConfiguration.class);
 		ConfigurationSetter setter = mock(ConfigurationSetter.class);
-		
-		XMLReader reader = createReader(PropertyBasedRequirementA.class, PropertyBasedRequirementB.class, PropertyBasedRequirementC.class);
-		configurator = new PropertyBasedConfigurator(reader, setter);
+		List<Object> configurations = new ArrayList<>();
+		PropertyBasedConfiguration config1 = mock(PropertyBasedConfiguration.class);
+		PropertyBasedConfiguration config2 = mock(PropertyBasedConfiguration.class);
+		TestCustomJavaConfiguration config3 = mock(TestCustomJavaConfiguration.class);
+		when(config1.getRequirementClassName()).thenReturn(PropertyBasedRequirementB.class.getCanonicalName());
+		when(config2.getRequirementClassName()).thenReturn(PropertyBasedRequirementA.class.getCanonicalName());
+		configurations.add(config1);
+		configurations.add(config2);
+		configurations.add(config3);
+		configurator = new PropertyBasedConfigurator(configurations, setter);
 
-		PropertyBasedRequirementA requirement = new PropertyBasedRequirementA(); 
+		PropertyBasedRequirementA requirement = new PropertyBasedRequirementA();
 		configurator.configure(requirement);
 
 		verify(setter).set(requirementArgument.capture(), configurationArgument.capture());
@@ -61,51 +71,52 @@ public class PropertyBasedConfiguratorTest {
 		assertThat(configurationArgument.getValue(), isA(PropertyBasedConfiguration.class));
 	}
 	
-	@Test
-	public void propertyBasedConfig_caching() {
-		XMLReader reader = createReader(PropertyBasedRequirementA.class, PropertyBasedRequirementB.class, PropertyBasedRequirementC.class);
-		configurator = new PropertyBasedConfigurator(reader, mock(ConfigurationSetter.class));
-
-		PropertyBasedRequirementA requirement = new PropertyBasedRequirementA(); 
-		configurator.configure(requirement);
-		
-		Object returned1 = configurator.getPropertyConfigurations().get(PropertyBasedRequirementA.class);
-		Object returned2 = configurator.getPropertyConfigurations().get(PropertyBasedRequirementA.class);
-
-		assertSame(returned1, returned2);
+	@Test(expected=RedDeerConfigurationException.class)
+	public void propertyBasedConfig_noConfigFound() {
+		configurator = new PropertyBasedConfigurator(new ArrayList<>(), mock(ConfigurationSetter.class));
+		configurator.configure(new PropertyBasedRequirementB());
 	}
 	
 	@Test(expected=RedDeerConfigurationException.class)
-	public void propertyBasedConfig_noConfigFound() {
-		XMLReader reader = createReader();
+	public void propertyBasedConfig_onlyCustomConfigFound() {
+		TestCustomJavaConfiguration customConfig = mock(TestCustomJavaConfiguration.class);
+		List<Object> configurations = new ArrayList<>();
+		configurations.add(customConfig);
 		
-		configurator = new PropertyBasedConfigurator(reader, mock(ConfigurationSetter.class));
-		configurator.configure(new PropertyBasedRequirementB());
+		configurator = new PropertyBasedConfigurator(configurations, mock(ConfigurationSetter.class));
+		configurator.configure(new PropertyBasedRequirementA());
 	}
 	
 	@Test(expected=RedDeerConfigurationException.class)
 	public void propertyBasedConfig_notConfigForClassFound() {
-		XMLReader reader = createReader(PropertyBasedRequirementA.class);
+		PropertyBasedConfiguration config = mock(PropertyBasedConfiguration.class);
+		List<Property> properties = new ArrayList<>();
+		properties.add(new Property("key1", "value1"));
+		// mock the behavior of config object to simulate some concrete configuration object
+		when(config.getProperties()).thenReturn(properties);
+		List<Object> configurations = new ArrayList<>();
+		configurations.add(config);
 		
-		configurator = new PropertyBasedConfigurator(reader, mock(ConfigurationSetter.class));
+		configurator = new PropertyBasedConfigurator(configurations, new ConfigurationSetter());
 		configurator.configure(new PropertyBasedRequirementB());
 	}
 	
-	@Test(expected=RedDeerConfigurationException.class)
 	public void propertyBasedConfig_moreConfigsFoundForSameClass() {
-		XMLReader reader = createReader(PropertyBasedRequirementA.class, PropertyBasedRequirementA.class);
+		List<Object> configurations = new ArrayList<>();
+		configurations.add(mock(PropertyBasedConfiguration.class));
+		configurations.add(mock(PropertyBasedConfiguration.class));
 		
-		configurator = new PropertyBasedConfigurator(reader, mock(ConfigurationSetter.class));
-		configurator.configure(new PropertyBasedRequirementB());
+		configurator = new PropertyBasedConfigurator(configurations, mock(ConfigurationSetter.class));
+		configurator.configure(new PropertyBasedRequirementA());
 	}
 	
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({ "rawtypes", "unchecked", "unused" })
 	private XMLReader createReader(Class<?>...classes) {
 		List<PropertyBasedConfiguration> configs = new ArrayList<PropertyBasedConfiguration>();
 		
 		for (Class clazz : classes){
 			PropertyBasedConfiguration config = mock(PropertyBasedConfiguration.class);
-			when(config.getRequirementClassName()).thenReturn(clazz.getCanonicalName());
+			//when(config.getRequirementClassName()).thenReturn(clazz.getCanonicalName());
 			configs.add(config);
 		}
 		
@@ -116,6 +127,16 @@ public class PropertyBasedConfiguratorTest {
 	
 	public static class PropertyBasedRequirementA implements Requirement<Annotation>, PropertyConfiguration {
 
+	    private String key1;
+	    
+	    public String getKey1() {
+	    	return key1;
+	    }
+		
+	    public void setKey1(String value) {
+	    	this.key1 = value;
+	    }
+	    
 		public boolean canFulfill() {
 			return false;
 		}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomJavaConfiguration.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomJavaConfiguration.java
@@ -1,0 +1,92 @@
+/******************************************************************************* 
+ * Copyright (c) 2017 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.reddeer.junit.test.internal.requirement;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "jre-requirement", namespace = "http://www.jboss.org/NS/jre-schema")
+public class TestCustomJavaConfiguration {
+
+		private String name;
+		
+		private String path;
+		
+		private double version;
+
+		/**
+		 * Gets name of this requirement to be used in eclipse.
+		 * @return JRE name
+		 */
+		public String getName() {
+			return name;
+		}
+		
+		/**
+		 * Gets path of where the JRE is installed .
+		 * @return path to JRE
+		 */
+		public String getPath() {
+			return path;
+		}
+
+		
+		/**
+		 * Gets version of JRE.
+		 *
+		 * @return the version
+		 */
+		public double getVersion() {
+			return version;
+		}
+
+		
+		private static String safeProperty(String s) {
+			if (s != null && s.startsWith("${") && s.endsWith("}")) {
+				String key = s.substring(2, s.length() - 1);
+				String v = System.getProperty(key);
+				if (v != null) {
+					return v;
+				}
+			}
+
+			return s;
+		}
+		
+		/**
+		 * Sets name of this JRE used in eclipse.
+		 * @param name Name of this JRE.
+		 */
+		@XmlElement(namespace = "http://www.jboss.org/NS/jre-schema")
+		public void setName(String name) {
+			this.name = safeProperty(name);
+		}
+
+		
+		/**
+		 * Sets path to JRE.
+		 * @param path Path to JRE.
+		 */
+		@XmlElement(namespace = "http://www.jboss.org/NS/jre-schema")
+		public void setPath(String path) {
+			this.path = safeProperty(path);
+		}
+
+		
+		/**
+		 * Sets version of JRE.
+		 * @param version Version of JRE.
+		 */
+		@XmlElement(namespace = "http://www.jboss.org/NS/jre-schema")
+		public void setVersion(double version) {
+			this.version = version;
+		}
+}

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomJavaRequirement.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomJavaRequirement.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -8,58 +8,54 @@
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/ 
-package org.jboss.reddeer.junit.test.integration.configuration;
+package org.jboss.reddeer.junit.test.internal.requirement;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
+import org.jboss.reddeer.junit.requirement.CustomConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
-import org.jboss.reddeer.junit.test.integration.configuration.RequirementB.RequirementBAnnotation;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaRequirement.CustomJavaAnnotation;
 
-public class RequirementB implements Requirement<RequirementBAnnotation>, PropertyConfiguration {
+public class TestCustomJavaRequirement implements Requirement<CustomJavaAnnotation>, CustomConfiguration<TestCustomJavaConfiguration> {
 
+	private TestCustomJavaConfiguration config;
+	
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
-	public @interface RequirementBAnnotation {
-	}	
-	
-	private String a;
-	
-	private String b;
+	public @interface CustomJavaAnnotation {
+	}
 	
 	public boolean canFulfill() {
-		return false;
+		return true;
 	}
 
 	public void fulfill() {
 	}
 	
-	public void setA(String a) {
-		this.a = a;
-	}
-	
-	public void setB(String b) {
-		this.b = b;
-	}
-	
-	public String getA() {
-		return a;
-	}
-	
-	public String getB() {
-		return b;
-	}
-	
 	@Override
-	public void setDeclaration(RequirementBAnnotation declaration) {
+	public void setDeclaration(CustomJavaAnnotation declaration) {
 	}
 
 	@Override
 	public void cleanUp() {
 		// TODO Auto-generated method stub
-		
 	}
+
+	@Override
+	public Class<TestCustomJavaConfiguration> getConfigurationClass() {
+		return TestCustomJavaConfiguration.class;
+	}
+
+	@Override
+	public void setConfiguration(TestCustomJavaConfiguration config) {
+		this.config = config;
+	}
+	
+	public TestCustomJavaConfiguration getConfig() {
+		return config;
+	}
+
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomServerConfiguration.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomServerConfiguration.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -8,7 +8,7 @@
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/ 
-package org.jboss.reddeer.requirements.server.apache.tomcat;
+package org.jboss.reddeer.junit.test.internal.requirement;
 
 import java.util.List;
 
@@ -18,17 +18,10 @@ import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.jboss.reddeer.requirements.server.IServerFamily;
-import org.jboss.reddeer.requirements.server.IServerReqConfig;
-
-
-/**
- * 
- * @author Pavol Srna 
- *
- */
+import org.jboss.reddeer.requirements.server.apache.tomcat.FamilyApacheTomcat;
 
 @XmlRootElement(name="server-requirement", namespace="http://www.jboss.org/NS/ServerReq")
-public class ServerRequirementConfig implements IServerReqConfig {
+public class TestCustomServerConfiguration {
 	
 	private String runtime;
 	
@@ -38,18 +31,10 @@ public class ServerRequirementConfig implements IServerReqConfig {
 	})
 	private List<IServerFamily> family;
 	
-	/* (non-Javadoc)
-	 * @see org.jboss.reddeer.requirements.server.IServerReqConfig#getServerFamily()
-	 */
-	@Override
-	public IServerFamily getServerFamily(){
+	public IServerFamily getServerFamily() {
 		return this.family.get(0); //always: size() == 1 
 	}
 	
-	/* (non-Javadoc)
-	 * @see org.jboss.reddeer.requirements.server.IServerReqConfig#getRuntime()
-	 */
-	@Override
 	public String getRuntime() {
 		return runtime;
 	}
@@ -62,27 +47,5 @@ public class ServerRequirementConfig implements IServerReqConfig {
 	@XmlElement(namespace="http://www.jboss.org/NS/ServerReq")
 	public void setRuntime(String runtime) {
 		this.runtime = runtime;
-	}
-	
-	/* (non-Javadoc)
-	 * @see java.lang.Object#equals(java.lang.Object)
-	 */
-	public boolean equals(Object arg) {
-		if(arg == null || !(arg instanceof ServerRequirementConfig))
-			return false;
-		if(arg == this)
-			return true;
-		ServerRequirementConfig conf = (ServerRequirementConfig) arg;
-		IServerFamily family1 = this.getServerFamily();
-		IServerFamily family2 = conf.getServerFamily();
-		if(!runtime.equals(conf.runtime) || (family1 == null && family2 != null))
-			return false;
-		return family1.getLabel().equals(family2.getLabel()) && family1.getVersion().equals(family2.getVersion());
-	}
-
-	@Override
-	public int hashCode() {
-		// TODO Auto-generated method stub
-		return super.hashCode();
 	}
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomServerRequirement.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestCustomServerRequirement.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -8,58 +8,54 @@
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/ 
-package org.jboss.reddeer.junit.test.integration.configuration;
+package org.jboss.reddeer.junit.test.internal.requirement;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
+import org.jboss.reddeer.junit.requirement.CustomConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
-import org.jboss.reddeer.junit.test.integration.configuration.RequirementB.RequirementBAnnotation;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerRequirement.CustomServerAnnotation;
 
-public class RequirementB implements Requirement<RequirementBAnnotation>, PropertyConfiguration {
+public class TestCustomServerRequirement implements Requirement<CustomServerAnnotation>, CustomConfiguration<TestCustomServerConfiguration> {
 
+	private TestCustomServerConfiguration config;
+	
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
-	public @interface RequirementBAnnotation {
-	}	
-	
-	private String a;
-	
-	private String b;
+	public @interface CustomServerAnnotation {
+	}
 	
 	public boolean canFulfill() {
-		return false;
+		return true;
 	}
 
 	public void fulfill() {
 	}
 	
-	public void setA(String a) {
-		this.a = a;
-	}
-	
-	public void setB(String b) {
-		this.b = b;
-	}
-	
-	public String getA() {
-		return a;
-	}
-	
-	public String getB() {
-		return b;
-	}
-	
 	@Override
-	public void setDeclaration(RequirementBAnnotation declaration) {
+	public void setDeclaration(CustomServerAnnotation declaration) {
 	}
 
 	@Override
 	public void cleanUp() {
 		// TODO Auto-generated method stub
-		
 	}
+
+	@Override
+	public Class<TestCustomServerConfiguration> getConfigurationClass() {
+		return TestCustomServerConfiguration.class;
+	}
+
+	@Override
+	public void setConfiguration(TestCustomServerConfiguration configuration) {
+		this.config = configuration;
+	}
+	
+	public TestCustomServerConfiguration getConfig() {
+		return this.config;
+	}
+
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestPropertyRequirementA.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestPropertyRequirementA.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -8,8 +8,9 @@
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/ 
-package org.jboss.reddeer.junit.test.integration.configuration;
+package org.jboss.reddeer.junit.test.internal.requirement;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,44 +18,32 @@ import java.lang.annotation.Target;
 
 import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
-import org.jboss.reddeer.junit.test.integration.configuration.RequirementB.RequirementBAnnotation;
 
-public class RequirementB implements Requirement<RequirementBAnnotation>, PropertyConfiguration {
+public class TestPropertyRequirementA implements Requirement<Annotation>, PropertyConfiguration {
 
+	private String property1;
+	
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
-	public @interface RequirementBAnnotation {
+	public @interface PropertyAnnotationA {
 	}	
 	
-	private String a;
-	
-	private String b;
-	
+	@Override
 	public boolean canFulfill() {
+		// TODO Auto-generated method stub
 		return false;
 	}
 
-	public void fulfill() {
-	}
-	
-	public void setA(String a) {
-		this.a = a;
-	}
-	
-	public void setB(String b) {
-		this.b = b;
-	}
-	
-	public String getA() {
-		return a;
-	}
-	
-	public String getB() {
-		return b;
-	}
-	
 	@Override
-	public void setDeclaration(RequirementBAnnotation declaration) {
+	public void fulfill() {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void setDeclaration(Annotation declaration) {
+		// TODO Auto-generated method stub
+		
 	}
 
 	@Override
@@ -62,4 +51,13 @@ public class RequirementB implements Requirement<RequirementBAnnotation>, Proper
 		// TODO Auto-generated method stub
 		
 	}
+
+	public String getProperty1() {
+		return property1;
+	}
+
+	public void setProperty1(String property1) {
+		this.property1 = property1;
+	}
+
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestPropertyRequirementB.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/TestPropertyRequirementB.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2016 Red Hat, Inc. 
+ * Copyright (c) 2017 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -8,8 +8,9 @@
  * Contributors: 
  * Red Hat, Inc. - initial API and implementation 
  ******************************************************************************/ 
-package org.jboss.reddeer.junit.test.integration.configuration;
+package org.jboss.reddeer.junit.test.internal.requirement;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,44 +18,34 @@ import java.lang.annotation.Target;
 
 import org.jboss.reddeer.junit.requirement.PropertyConfiguration;
 import org.jboss.reddeer.junit.requirement.Requirement;
-import org.jboss.reddeer.junit.test.integration.configuration.RequirementB.RequirementBAnnotation;
 
-public class RequirementB implements Requirement<RequirementBAnnotation>, PropertyConfiguration {
+public class TestPropertyRequirementB implements Requirement<Annotation>, PropertyConfiguration {
 
+	private String property1;
+	
+	private String property2;
+	
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.TYPE)
-	public @interface RequirementBAnnotation {
-	}	
-	
-	private String a;
-	
-	private String b;
-	
-	public boolean canFulfill() {
-		return false;
-	}
-
-	public void fulfill() {
-	}
-	
-	public void setA(String a) {
-		this.a = a;
-	}
-	
-	public void setB(String b) {
-		this.b = b;
-	}
-	
-	public String getA() {
-		return a;
-	}
-	
-	public String getB() {
-		return b;
+	public @interface PropertyAnnotationB {
 	}
 	
 	@Override
-	public void setDeclaration(RequirementBAnnotation declaration) {
+	public boolean canFulfill() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
+	public void fulfill() {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void setDeclaration(Annotation declaration) {
+		// TODO Auto-generated method stub
+		
 	}
 
 	@Override
@@ -62,4 +53,21 @@ public class RequirementB implements Requirement<RequirementBAnnotation>, Proper
 		// TODO Auto-generated method stub
 		
 	}
+
+	public String getProperty1() {
+		return property1;
+	}
+
+	public void setProperty1(String property1) {
+		this.property1 = property1;
+	}
+
+	public String getProperty2() {
+		return property2;
+	}
+
+	public void setProperty2(String property2) {
+		this.property2 = property2;
+	}
+
 }

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/parameterized/inject/ParameterizedRequirementTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/internal/requirement/parameterized/inject/ParameterizedRequirementTest.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package org.jboss.reddeer.junit.test.internal.requirement.parameterized.inject;
 
+import org.jboss.reddeer.common.properties.RedDeerProperties;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
 import org.junit.Test;
 import org.junit.internal.builders.AllDefaultPossibilitiesBuilder;
@@ -21,6 +22,7 @@ public class ParameterizedRequirementTest {
 
 	@Test
 	public void testStaticInject() throws InitializationError {
+		System.clearProperty(RedDeerProperties.CONFIG_FILE.getName());
 		RunNotifier notifier = new RunNotifier();
 		RedDeerSuite rs = new RedDeerSuite(ParameterizedStaticReqTestClazz.class, new AllDefaultPossibilitiesBuilder(true));
 		rs.run(notifier);

--- a/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/runner/RedDeerSuiteTest.java
+++ b/tests/org.jboss.reddeer.junit.test/src/org/jboss/reddeer/junit/test/runner/RedDeerSuiteTest.java
@@ -14,78 +14,149 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.io.File;
 import java.util.List;
 
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.jboss.reddeer.common.properties.RedDeerProperties;
 import org.jboss.reddeer.junit.internal.configuration.SuiteConfiguration;
-import org.jboss.reddeer.junit.internal.configuration.TestRunConfiguration;
-import org.jboss.reddeer.junit.internal.requirement.Requirements;
 import org.jboss.reddeer.junit.internal.runner.NamedSuite;
-import org.jboss.reddeer.junit.internal.runner.RequirementsRunnerBuilder;
 import org.jboss.reddeer.junit.internal.runner.TestsWithoutExecutionSuite;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerConfiguration;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomJavaRequirement.CustomJavaAnnotation;
+import org.jboss.reddeer.junit.test.internal.requirement.TestCustomServerRequirement.CustomServerAnnotation;
+import org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementA.PropertyAnnotationA;
+import org.jboss.reddeer.junit.test.internal.requirement.TestPropertyRequirementB.PropertyAnnotationB;
+import org.jboss.reddeer.junit.test.runner.UnfulfillableRequirement.Unfulfillable;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.Runner;
-import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.junit.runners.model.InitializationError;
 
 public class RedDeerSuiteTest {
 
+	private static final String LOCATIONS_ROOT_DIR;
+	
+	static{
+		StringBuffer sbRootDir = new StringBuffer("");
+		sbRootDir.append("resources");
+		sbRootDir.append(File.separator);
+		sbRootDir.append("org");
+		sbRootDir.append(File.separator);
+		sbRootDir.append("jboss");
+		sbRootDir.append(File.separator);
+		sbRootDir.append("reddeer");
+		sbRootDir.append(File.separator);
+		sbRootDir.append("junit");
+		sbRootDir.append(File.separator);
+		sbRootDir.append("test");
+		sbRootDir.append(File.separator);
+		sbRootDir.append("runner");
+		sbRootDir.append(File.separator);
+		LOCATIONS_ROOT_DIR = sbRootDir.toString();
+	}
+	
+	@After
+	public void tearDown() {
+		System.clearProperty(RedDeerProperties.CONFIG_FILE.getName());
+	}
+	
 	@Test
 	public void getChildren_noConfiguration() throws InitializationError {
-		SuiteConfiguration config = mock(SuiteConfiguration.class);
-		when(config.getTestRunConfigurations()).thenReturn(new ArrayList<TestRunConfiguration>());
+		SuiteConfiguration config = new SuiteConfiguration(SimpleTest.class);
 		
-		List<Runner> runners = RedDeerSuite.createSuite(SimpleSuite.class, config);
+		List<Runner> runners = RedDeerSuite.createSuites(SimpleSuite.class, config);
 		
-		assertThat(runners.size(), is(0));
+		// will create one test run defined by NullTestRunConfiguration
+		assertThat(runners.size(), is(1));
+	}
+	
+	@Test
+	public void getChildren_suiteWithRequirements() throws InitializationError {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				LOCATIONS_ROOT_DIR + File.separator + "requirements.xml");
+		
+		SuiteConfiguration config = new SuiteConfiguration(CustomRequirementsSuite.class);
+		
+		List<Runner> runners = RedDeerSuite.createSuites(CustomRequirementsSuite.class, config);
+
+		assertThat(runners.size(), is(4));
+		
+		String server = TestCustomServerConfiguration.class.getSimpleName();
+		String java = TestCustomJavaConfiguration.class.getSimpleName();
+		
+		boolean hasComplexSuite = false;
+		for (Runner run : runners) {
+			String suiteName = run.getDescription().getDisplayName();
+			if ((server + " " + java).equalsIgnoreCase(suiteName) ||
+				(java + " " + server).equalsIgnoreCase(suiteName)) {
+				hasComplexSuite = true;
+				break;
+			}
+		}
+		
+		assertTrue("Test runners do not contain suite with name " + server + " " + java + " or vice versa", hasComplexSuite);
+		assertThat(runners, hasItem(new NamedSuiteMatcher(server)));
+		assertThat(runners, hasItem(new NamedSuiteMatcher(java)));
+		assertThat(runners, hasItem(new NamedSuiteMatcher("default")));
 	}
 	
 	@Test
 	public void getChildren_suite() throws InitializationError {
-		SuiteConfiguration config = mock(SuiteConfiguration.class);
-		List<TestRunConfiguration> testRunConfigurations = Arrays.asList(mockTestRunConfig("A"), mockTestRunConfig("B"), mockTestRunConfig("C")); 
-		when(config.getTestRunConfigurations()).thenReturn(testRunConfigurations);
+		SuiteConfiguration config = new SuiteConfiguration(SimpleSuite.class);
 		
-		List<Runner> runners = RedDeerSuite.createSuite(SimpleSuite.class, config);
+		List<Runner> runners = RedDeerSuite.createSuites(SimpleSuite.class, config);
 		
-		assertThat(runners, hasItem(new NamedSuiteMatcher("A")));
-		assertThat(runners, hasItem(new NamedSuiteMatcher("B")));
-		assertThat(runners, hasItem(new NamedSuiteMatcher("C")));
+		assertThat(runners, hasItem(new NamedSuiteMatcher("default")));
+	}
+	
+	@Test
+	public void getChildren_nestedSuite() throws InitializationError {
+		SuiteConfiguration config = new SuiteConfiguration(NestedSuite.class);
+		
+		List<Runner> runners = RedDeerSuite.createSuites(SimpleSuite.class, config);
+		
+		assertThat(runners, hasItem(new NamedSuiteMatcher("default")));
 	}
 
 	@Test
 	public void getChildren_test() throws InitializationError {
-		SuiteConfiguration config = mock(SuiteConfiguration.class);
-		List<TestRunConfiguration> testRunConfigurations = Arrays.asList(mockTestRunConfig("A"), mockTestRunConfig("B"), mockTestRunConfig("C")); 
-		when(config.getTestRunConfigurations()).thenReturn(testRunConfigurations);
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				LOCATIONS_ROOT_DIR + File.separator + "requirements.xml");		
+		SuiteConfiguration config = new SuiteConfiguration(SimpleTest.class);
 		
-		List<Runner> runners = RedDeerSuite.createSuite(SimpleTest.class, config);
+		List<Runner> runners = RedDeerSuite.createSuites(SimpleTest.class, config);
+
+		assertThat(runners.size(), is(1));
+		assertThat(runners, hasItem(new NamedSuiteMatcher("default")));
 		
-		assertThat(runners, hasItem(new NamedSuiteMatcher("A")));
-		assertThat(runners, hasItem(new NamedSuiteMatcher("B")));
-		assertThat(runners, hasItem(new NamedSuiteMatcher("C")));
+		config = null;
+		runners.clear();
+		
+		config = new SuiteConfiguration(CustomRequirementTest1.class);
+		
+		runners = RedDeerSuite.createSuites(CustomRequirementTest1.class, config);
+
+		assertThat(runners.size(), is(1));
+		assertThat(runners, hasItem(new NamedSuiteMatcher(TestCustomJavaConfiguration.class.getSimpleName())));
 	}
 	
 	@Test
 	public void testsWithoutExecution_suite() throws InitializationError {
-		SuiteConfiguration config = mock(SuiteConfiguration.class);
-		List<TestRunConfiguration> testRunConfigurations = Arrays.asList(
-				mockTestRunConfig("A"), mockTestRunConfig("B"),
-				mockUnfulfillableTestRunConfig("C"));
-		when(config.getTestRunConfigurations()).thenReturn(testRunConfigurations);
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				LOCATIONS_ROOT_DIR + File.separator + "requirements.xml");
+		SuiteConfiguration config = new SuiteConfiguration(UnfillableSuite.class);
 		
-		List<Runner> runners = RedDeerSuite.createSuite(SimpleSuite.class, config);
+		List<Runner> runners = RedDeerSuite.createSuites(UnfillableSuite.class, config);
 		
-		assertThat(runners, hasItem(new NamedSuiteMatcher("A")));
-		assertThat(runners, hasItem(new NamedSuiteMatcher("B")));
+		assertThat(runners.size(), is(3));
+		assertThat(runners, hasItem(new NamedSuiteMatcher("default")));
+		assertThat(runners, hasItem(new NamedSuiteMatcher(TestCustomJavaConfiguration.class.getSimpleName())));
 		
 		Runner runner = runners.get(runners.size()-1);
 		assertTrue(runner.getClass().toString(), runner instanceof TestsWithoutExecutionSuite);
@@ -93,60 +164,100 @@ public class RedDeerSuiteTest {
 
 	@Test
 	public void testsWithoutExecution_test() throws InitializationError {
-		SuiteConfiguration config = mock(SuiteConfiguration.class);
-		List<TestRunConfiguration> testRunConfigurations = Arrays.asList(
-				mockTestRunConfig("A"), mockTestRunConfig("B"),
-				mockUnfulfillableTestRunConfig("C"));
-		when(config.getTestRunConfigurations()).thenReturn(testRunConfigurations);
+		SuiteConfiguration config = new SuiteConfiguration(SimpleTest.class);
 		
-		List<Runner> runners = RedDeerSuite.createSuite(SimpleTest.class, config);
+		List<Runner> runners = RedDeerSuite.createSuites(SimpleTest.class, config);
 		
-		assertThat(runners, hasItem(new NamedSuiteMatcher("A")));
-		assertThat(runners, hasItem(new NamedSuiteMatcher("B")));
+		assertThat(runners.size(), is(1));
+		assertThat(runners, hasItem(new NamedSuiteMatcher("default")));
 		
 		Runner runner = runners.get(runners.size()-1);
+		assertFalse(runner instanceof TestsWithoutExecutionSuite);
+		
+		config = new SuiteConfiguration(UnfillableTestClass.class);
+		runners = RedDeerSuite.createSuites(UnfillableTestClass.class, config);
+		
+		assertThat(runners.size(), is(2));
+		assertThat(runners, hasItem(new NamedSuiteMatcher("default")));
+		
+		runner = runners.get(runners.size()-1);
 		assertTrue(runner instanceof TestsWithoutExecutionSuite);
 	}
 	
 	@Test
-	public void testNesteSuite() throws Throwable{
-		assertEquals(1,getTestCount(ParentSuite.class));
+	public void testNestedSuite() throws Throwable {
+		assertEquals(1, getTestCount(ParentSuite.class));
 	}
 	
 	@Test
-	public void testNesteSuiteWithTests() throws Throwable{
-		assertEquals(2,getTestCount(ParentSuite1.class));
+	public void testNestedSuiteWithTests() throws Throwable {
+		assertEquals(2, getTestCount(ParentSuite1.class));
 	}
 	
-	private int getTestCount(@SuppressWarnings("rawtypes") Class suiteClass) throws Throwable{
-		SuiteConfiguration config = mock(SuiteConfiguration.class);
-		List<TestRunConfiguration> testRunConfigurations = Arrays.asList(
-				mockTestRunConfig("A"));
-		when(config.getTestRunConfigurations()).thenReturn(testRunConfigurations);
-		
-		List<Runner> runners = RedDeerSuite.createSuite(suiteClass, config);
-		RequirementsRunnerBuilder builder = (RequirementsRunnerBuilder)((NamedSuite)runners.get(0)).getRunnerBuilder();
-		
-		Runner testRunner = builder.runnerForClass(suiteClass);
-		assertTrue(testRunner.getClass().equals(Suite.class));
-		return testRunner.testCount();
+	@Test
+	public void testRequirementsSuite() throws Throwable {
+		assertEquals(4, getTestCount(CustomRequirementsSuite.class));
 	}
 	
-	private TestRunConfiguration mockTestRunConfig(String id){
-		TestRunConfiguration c = mock(TestRunConfiguration.class);
-		when(c.getId()).thenReturn(id);
-		return c;
+	@Test
+	public void testRequirementsSuite_withConfig() throws Throwable {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				LOCATIONS_ROOT_DIR + File.separator + "requirements2.xml");
+		
+		assertEquals(9, getTestCount(CustomRequirementsSuite.class));
+	}
+	
+	@Test
+	public void testPropertyRequirementsSuite() throws Throwable {
+		assertEquals(4, getTestCount(PropertyRequirementsSuite.class));
 	}
 
-	private TestRunConfiguration mockUnfulfillableTestRunConfig(String id){
-		TestRunConfiguration c = mock(UnfulfillableTestRunConfiguration.class);
-		when(c.getId()).thenReturn(id);
-		return c;
+	@Test
+	public void testPropertyRequirementsSuite_withConfig() throws Throwable {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				LOCATIONS_ROOT_DIR + File.separator + "requirements3.xml");
+		
+		assertEquals(6, getTestCount(PropertyRequirementsSuite.class));
 	}
 	
-	@UnfulfillableRequirement.Unfulfillable
-	public static abstract class UnfulfillableTestRunConfiguration implements TestRunConfiguration {
-
+	@Test
+	public void testMixedRequirementsSuite() throws Throwable {
+		assertEquals(6, getTestCount(MixedRequirementsSuite.class));
+		// set rd.config property
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				LOCATIONS_ROOT_DIR + File.separator + "requirements4.xml");
+		
+		assertEquals(23, getTestCount(MixedRequirementsSuite.class));
+	}
+	
+	@Test
+	public void testUnfillableSuite() throws Throwable {
+		assertEquals(3, getTestCount(UnfillableSuite.class));
+	}
+	
+	@Test
+	public void testMixedTestClasses() throws Throwable {
+		System.setProperty(RedDeerProperties.CONFIG_FILE.getName(), 
+				LOCATIONS_ROOT_DIR + File.separator + "requirements4.xml");
+		assertEquals(2, getTestCount(MixedTest1.class));
+		assertEquals(4, getTestCount(MixedTest2.class));
+		assertEquals(4, getTestCount(MixedTest3.class));
+		assertEquals(8, getTestCount(MixedTest4.class));
+		assertEquals(8, getTestCount(MixedTest5.class));
+	}
+	
+	private int getTestCount(@SuppressWarnings("rawtypes") Class suiteClass) throws Throwable {
+		SuiteConfiguration config = new SuiteConfiguration(suiteClass);
+		
+		List<Runner> runners = RedDeerSuite.createSuites(suiteClass, config);
+		short testCount = 0;
+		for (Runner runner : runners) {
+			if (!(runner instanceof TestsWithoutExecutionSuite)) {
+				testCount += runner.getDescription().testCount();
+			}
+		}
+		
+		return testCount;
 	}
 	
 	class NamedSuiteMatcher extends TypeSafeMatcher<Runner> {
@@ -167,16 +278,10 @@ public class RedDeerSuiteTest {
 		}
 	}
 	
+	// TEST SUITES
+	
 	@SuiteClasses({SimpleTest.class})
 	public static class SimpleSuite {
-		
-	}
-	
-	public static class SimpleTest {
-		
-	}
-	
-	public static class SimpleTest1 {
 		
 	}
 	
@@ -197,4 +302,99 @@ public class RedDeerSuiteTest {
 	public static class ParentSuite1 {
 		
 	}
+	
+	@SuiteClasses({
+		CustomRequirementTest1.class,
+		CustomRequirementTest2.class,
+		CustomRequirementTest3.class,
+		NoRequirementTest4.class
+	})
+	public static class CustomRequirementsSuite {
+		
+	}
+	
+	@SuiteClasses({
+		SimpleTest.class,
+		SimpleTest1.class,
+		UnfillableTestClass.class,
+		CustomRequirementTest1.class
+	})
+	public static class UnfillableSuite {}
+	
+	@SuiteClasses({
+		PropertyTest1.class,
+		PropertyTest2.class,
+		PropertyTest3.class,
+		NoRequirementTest4.class
+	})
+	public static class PropertyRequirementsSuite {
+
+	}
+	
+	@SuiteClasses({
+		MixedTest1.class,
+		MixedTest2.class,
+		MixedTest3.class,
+		MixedTest4.class,
+		MixedTest5.class,
+		NoRequirementTest4.class
+	})
+	public static class MixedRequirementsSuite {}
+	
+	// TEST CLASSES
+	
+	@Unfulfillable
+	public static class UnfillableTestClass {}
+	
+	public static class SimpleTest {}
+	
+	public static class SimpleTest1 {}
+	
+	@CustomJavaAnnotation
+	public static class CustomRequirementTest1 {}
+	
+	@CustomServerAnnotation
+	public static class CustomRequirementTest2 {}
+	
+	@CustomJavaAnnotation
+	@CustomServerAnnotation
+	public static class CustomRequirementTest3 {}
+	
+	public static class NoRequirementTest4 {}
+	
+	@PropertyAnnotationA
+	public static class PropertyTest1 {}
+	
+	@PropertyAnnotationB
+	public static class PropertyTest2 {}
+	
+	@PropertyAnnotationA
+	@PropertyAnnotationB
+	public static class PropertyTest3 {}
+	
+	@PropertyAnnotationA
+	@CustomJavaAnnotation
+	public static class MixedTest1 {}
+	
+	@PropertyAnnotationA
+	@PropertyAnnotationB
+	@CustomJavaAnnotation
+	public static class MixedTest2 {}
+	
+	@PropertyAnnotationA
+	@PropertyAnnotationB
+	@CustomJavaAnnotation
+	public static class MixedTest3 {}
+	
+	@PropertyAnnotationB
+	@CustomJavaAnnotation
+	@CustomServerAnnotation
+	public static class MixedTest4 {}
+	
+	@PropertyAnnotationA
+	@PropertyAnnotationB
+	@CustomJavaAnnotation
+	@CustomServerAnnotation
+	public static class MixedTest5 {}
+	
 }

--- a/tests/org.jboss.reddeer.requirements.test/pom.xml
+++ b/tests/org.jboss.reddeer.requirements.test/pom.xml
@@ -16,7 +16,7 @@
 		<apache-tomcat-7.version>7.0.56</apache-tomcat-7.version>
 		<apache-tomcat-7.mirror>http://archive.apache.org/dist/tomcat/tomcat-7/</apache-tomcat-7.mirror>
 		<apache-tomcat-7.home>${project.build.directory}/apache-tomcat-${apache-tomcat-7.version}</apache-tomcat-7.home>
-		<customArgLine>-Drd.config=${basedir}/bin</customArgLine>
+		<customArgLine>-Drd.config=${basedir}/bin/requirements.xml</customArgLine>
 	</properties>
 
 	<profiles>

--- a/tests/org.jboss.reddeer.requirements.test/resources/JRE17.xml
+++ b/tests/org.jboss.reddeer.requirements.test/resources/JRE17.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reddeer
+	xmlns="http://www.jboss.org/NS/Req" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:server="http://www.jboss.org/NS/ServerReq"
+	xmlns:jre="http://www.jboss.org/NS/jre-schema"
+	xsi:schemaLocation="http://www.jboss.org/NS/Req http://www.jboss.org/schema/reddeer/v1/RedDeerSchema.xsd
+						http://www.jboss.org/NS/jre-schema http://www.jboss.org/schema/reddeer/v1/JRERequirement.xsd
+						http://www.jboss.org/NS/ServerReq http://www.jboss.org/schema/reddeer/v1/ApacheServerRequirements.xsd">
+
+	<requirements>
+		<!-- Example server configuration -->
+		
+		<server:server-requirement name="Tomcat7">
+			<server:type>
+				<server:familyApacheTomcat version="7.0" />
+			</server:type>
+			<server:runtime>${apache-tomcat-7.home}</server:runtime>
+		</server:server-requirement>
+		<!--
+		<server:jboss-server-requirement name="AS-7.1">
+			<server:type>
+				<server:familyAS version="7.1"></server:familyAS>
+			</server:type>
+			<server:runtime>/home/odockal/Programs/Server/jboss-eap-7.0</server:runtime>
+		</server:jboss-server-requirement>  -->
+		<server:server-requirement name="Tomcat8">
+			<server:type>
+				<server:familyApacheTomcat version="8.0" />
+			</server:type>
+			<server:runtime>${apache-tomcat-8.home}</server:runtime>
+		</server:server-requirement>
+		
+		<!-- JRE requirement definition -->
+		<jre:jre-requirement name="JRE-1.7">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.7</jre:version>
+        	<jre:path>/home/odockal/Programs/Java/jre1.7.0_80</jre:path>
+		</jre:jre-requirement> 
+		<jre:jre-requirement name="JRE-1.8">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.8</jre:version>
+        	<jre:path>/home/odockal/Programs/Java/jre1.8.0_121</jre:path>
+		</jre:jre-requirement>
+		<jre:jre-requirement name="JRE-1.71">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.7</jre:version>
+        	<jre:path>/home/odockal/Programs/Java/jre1.7.0_80</jre:path>
+		</jre:jre-requirement> 
+		<jre:jre-requirement name="JRE-1.81">
+        	<jre:name>jre</jre:name>
+        	<jre:version>1.8</jre:version>
+        	<jre:path>/home/odockal/Programs/Java/jre1.8.0_121</jre:path>
+		</jre:jre-requirement>    
+		<!-- Property requirements -->
+		<requirement class="org.jboss.reddeer.req.test.UserRequirement"
+            name="userRequirement">
+            <property key="name" value="USERS_ADMINISTRATION" />
+            <property key="ip" value="127.0.0.1" />
+        </requirement>
+	</requirements>
+</reddeer>


### PR DESCRIPTION
Aim is to be able to run multiple test runs on single test suite based on annotated requirements loaded from single config file. This is especially aiming to use of JRE and Server (only to those?) requirements together defined with one single config xml file. Such loaded requirement configuration would create matrix of combination of possible configurations that would test suite be run with.