### PR TITLE
Improve the logic for tabbed properties

### DIFF
--- a/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
+++ b/plugins/org.jboss.reddeer.eclipse/src/org/jboss/reddeer/eclipse/ui/views/properties/PropertiesView.java
@@ -106,7 +106,9 @@ public class PropertiesView extends WorkbenchView{
 		}catch(Exception ex) {
 			//probably not rendered yet
 		}
-		new WaitUntil(new AnotherTabsRendered(old), TimePeriod.NORMAL, false);
+		if (!old.contains(label)) {
+			new WaitUntil(new AnotherTabsRendered(old), TimePeriod.NORMAL, false);	
+		}
 		
 		new TabbedPropertyList().selectTab(label);
 	}

--- a/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/properties/PropertiesViewTest.java
+++ b/tests/org.jboss.reddeer.eclipse.test/src/org/jboss/reddeer/eclipse/test/ui/views/properties/PropertiesViewTest.java
@@ -20,10 +20,12 @@ import org.jboss.reddeer.core.exception.CoreLayerException;
 import org.jboss.reddeer.eclipse.jdt.ui.packageexplorer.PackageExplorer;
 import org.jboss.reddeer.eclipse.jdt.ui.wizards.JavaProjectWizard;
 import org.jboss.reddeer.eclipse.jdt.ui.wizards.NewJavaProjectWizardPageOne;
+import org.jboss.reddeer.eclipse.ui.perspectives.JavaPerspective;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesView;
 import org.jboss.reddeer.eclipse.ui.views.properties.PropertiesViewProperty;
 import org.jboss.reddeer.eclipse.utils.DeleteUtils;
 import org.jboss.reddeer.junit.runner.RedDeerSuite;
+import org.jboss.reddeer.requirements.openperspective.OpenPerspectiveRequirement.OpenPerspective;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +36,7 @@ import org.junit.runner.RunWith;
  *
  */
 @RunWith(RedDeerSuite.class)
+@OpenPerspective(JavaPerspective.class)
 public class PropertiesViewTest {
 	private static final String TEST_PROJECT_NAME = "PropertiesViewTestProject";
 


### PR DESCRIPTION
Currently, it takes ages to select a tab. This is ok since there are lots of necessary wait conditions. But these conditions are also applied if we try to select already selected tab. I suggest to add some check whether the required tab is already selected and skip the wait conditions.