### PR TITLE
Add an option to ignore asterisks

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/matcher/WithLabelMatcher.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/matcher/WithLabelMatcher.java
@@ -75,8 +75,15 @@ public class WithLabelMatcher extends BaseMatcher<String> {
 		if ((item instanceof List) || (item instanceof Text) || (item instanceof Button)
 				|| (item instanceof Combo) || (item instanceof CCombo) || (item instanceof Spinner)) {
 			String widgetLabel = WidgetLookup.getInstance().getLabel((Widget)item);
-			if (widgetLabel != null && matcher.matches(widgetLabel)) {
-				return true;
+			if (widgetLabel != null) {
+				// Ignore asterisk and spaces
+				String widgetLabel2 = widgetLabel.trim();
+				if (widgetLabel2.endsWith("*")) {
+					widgetLabel2 = widgetLabel2.substring(0, widgetLabel2.length() - 1).trim();
+				}
+				if (matcher.matches(widgetLabel) || matcher.matches(widgetLabel2)) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
+++ b/tests/org.jboss.reddeer.swt.test/src/org/jboss/reddeer/swt/test/impl/text/LabeledTextTest.java
@@ -109,6 +109,13 @@ public class LabeledTextTest extends SWTLayerTestCase {
 		LabelTestUtils.createLabel(shell, "Test label4");
 		Composite composite = new Composite(shell, SWT.LEFT);
 		TextTestUtils.createText(composite, "Test text4");
+		
+		LabelTestUtils.createLabel(shell, "Required label1*");
+		TextTestUtils.createText(shell, "Required text1");
+		LabelTestUtils.createLabel(shell, "Required label2 *");
+		TextTestUtils.createText(shell, "Required text2");
+		LabelTestUtils.createLabel(shell, "Special label?");
+		TextTestUtils.createText(shell, "Special text");
 	}
 	
 	@Test
@@ -151,6 +158,36 @@ public class LabeledTextTest extends SWTLayerTestCase {
 	public void findLabeledTextWithOutsideLabel(){
 		new DefaultShell(SHELL_TITLE);
 		assertTrue(new LabeledText("Test label4").getText().equals("Test text4"));
+	}
+	
+	@Test
+	public void findLabeledTextWithAsterisk() {
+		new DefaultShell(SHELL_TITLE);
+		assertEquals("Required text1", new LabeledText("Required label1*").getText());
+	}
+
+	@Test
+	public void findLabeledTextForRequiredField() {
+		new DefaultShell(SHELL_TITLE);
+		assertEquals("Required text1", new LabeledText("Required label1").getText());
+	}
+	
+	@Test
+	public void findLabeledTextWithAsteriskWithSpace() {
+		new DefaultShell(SHELL_TITLE);
+		assertEquals("Required text2", new LabeledText("Required label2 *").getText());
+	}
+
+	@Test
+	public void findLabeledTextForRequiredFieldWithSpace() {
+		new DefaultShell(SHELL_TITLE);
+		assertEquals("Required text2", new LabeledText("Required label2").getText());
+	}
+	
+	@Test
+	public void findLabeledTextWithSpecialChar() {
+		new DefaultShell(SHELL_TITLE);
+		assertEquals("Special text", new LabeledText("Special label?").getText());
 	}
 
 	@Test


### PR DESCRIPTION
I suggest to extend WithLabelMatcher by an option to ignore asterisks, wdyt?
