### PR TITLE
Provide Image to RedDeer Launch Configuration tab

### DIFF
--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/launcher/RedDeerJUnitTab.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/launcher/RedDeerJUnitTab.java
@@ -24,40 +24,24 @@ import org.eclipse.jface.viewers.ColumnLayoutData;
 import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.jface.viewers.ComboBoxViewerCellEditor;
-import org.eclipse.jface.viewers.DialogCellEditor;
 import org.eclipse.jface.viewers.EditingSupport;
 import org.eclipse.jface.viewers.ICellEditorListener;
 import org.eclipse.jface.viewers.TableLayout;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.viewers.TextCellEditor;
-import org.eclipse.jface.viewers.ViewerCell;
-import org.eclipse.jface.viewers.ViewerColumn;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.custom.TableEditor;
-import org.eclipse.swt.events.FocusAdapter;
-import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.KeyAdapter;
-import org.eclipse.swt.events.KeyEvent;
-import org.eclipse.swt.events.MouseAdapter;
-import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TableItem;
-import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 import org.jboss.reddeer.common.exception.RedDeerException;
 import org.jboss.reddeer.common.properties.RedDeerProperties;
 import org.jboss.reddeer.common.properties.RedDeerPropertyType;
+import org.jboss.reddeer.ui.Activator;
 
 /**
  * Specialized tab for configuring Red Deer properties
@@ -89,6 +73,11 @@ public class RedDeerJUnitTab extends AbstractLaunchConfigurationTab {
 	@Override
 	public String getName() {
 		return "Red Deer";
+	}
+	
+	@Override
+	public Image getImage() {
+		return Activator.getDefault().getImageRegistry().get(Activator.REDDEER_RUNNER);
 	}
 
 	@Override
@@ -236,13 +225,6 @@ public class RedDeerJUnitTab extends AbstractLaunchConfigurationTab {
 		}
 	}
 	
-	private class CustomTextCellEditor extends TextCellEditor{
-		@Override
-		public Control createControl(Composite parent) {
-			return super.createControl(parent);
-		}
-	}
-
 	private class RedDeerEditingSupport extends EditingSupport {
 
 		public RedDeerEditingSupport(ColumnViewer viewer) {

--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestPluginWizardPage.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestPluginWizardPage.java
@@ -15,10 +15,6 @@ import java.util.List;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.pde.core.plugin.TargetPlatform;
 import org.eclipse.swt.SWT;
@@ -72,9 +68,7 @@ public class NewRedDeerTestPluginWizardPage extends WizardPage implements
 
 		setDescription("Specify the test plugin properties.");
 
-		setImageDescriptor(ImageDescriptor.createFromURL(FileLocator.find(
-				Platform.getBundle(Activator.PLUGIN_ID), new Path(
-						"resources/reddeer_icon.png"), null)));
+		setImageDescriptor(Activator.getDefault().getImageRegistry().getDescriptor(Activator.REDDEER_ICON));
 		setPageComplete(false);
 
 	}

--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestWizardPageOne.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestWizardPageOne.java
@@ -11,10 +11,7 @@
 package org.jboss.reddeer.eclipse.ui.wizards;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
@@ -25,7 +22,6 @@ import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.junit.wizards.NewTestCaseWizardPageOne;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.jboss.reddeer.ui.Activator;
 
@@ -41,9 +37,7 @@ public class NewRedDeerTestWizardPageOne extends NewTestCaseWizardPageOne {
 		super(pageTwo);
 		setTitle("Red Deer Test Case");
 
-		setImageDescriptor(ImageDescriptor.createFromURL(FileLocator.find(
-				Platform.getBundle(Activator.PLUGIN_ID), new Path(
-						"resources/reddeer_icon.png"), null)));
+		setImageDescriptor(Activator.getDefault().getImageRegistry().getDescriptor(Activator.REDDEER_ICON));
 	}
 
 	@Override

--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestWizardPageTwo.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/eclipse/ui/wizards/NewRedDeerTestWizardPageTwo.java
@@ -10,11 +10,7 @@
  ******************************************************************************/ 
 package org.jboss.reddeer.eclipse.ui.wizards;
 
-import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.junit.wizards.NewTestCaseWizardPageTwo;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.jboss.reddeer.ui.Activator;
 
 /**
@@ -28,8 +24,6 @@ public class NewRedDeerTestWizardPageTwo extends NewTestCaseWizardPageTwo {
 
 	protected NewRedDeerTestWizardPageTwo() {
 		super();
-		setImageDescriptor(ImageDescriptor.createFromURL(FileLocator.find(
-				Platform.getBundle(Activator.PLUGIN_ID), new Path(
-						"resources/reddeer_icon.png"), null)));
+		setImageDescriptor(Activator.getDefault().getImageRegistry().getDescriptor(Activator.REDDEER_ICON));
 	}
 }

--- a/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/ui/Activator.java
+++ b/plugins/org.jboss.reddeer.ui/src/org/jboss/reddeer/ui/Activator.java
@@ -10,8 +10,15 @@
  ******************************************************************************/ 
 package org.jboss.reddeer.ui;
 
+import java.net.URL;
+import java.util.Collections;
+
+import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -27,6 +34,9 @@ public class Activator extends AbstractUIPlugin {
 	// independent from SWTBot.
 	public static final String APPLICATION_ID = PLUGIN_ID
 			+ ".reddeertestapplication"; //$NON-NLS-1$
+
+	public static final String REDDEER_ICON = "reddeer_icon";
+	public static final String REDDEER_RUNNER = "reddeer_runner";
 
 	// The shared instance
 	private static Activator plugin;
@@ -84,5 +94,18 @@ public class Activator extends AbstractUIPlugin {
 	public static void logWarning(String message) {
 		IStatus status = new Status(IStatus.WARNING, PLUGIN_ID, message);
 		plugin.getLog().log(status);
+	}
+	
+	@Override
+	protected void initializeImageRegistry(ImageRegistry reg) {
+		super.initializeImageRegistry(reg);
+		initializeImageRegistry(reg, REDDEER_ICON);
+		initializeImageRegistry(reg, REDDEER_RUNNER);
+	}
+
+	private void initializeImageRegistry(ImageRegistry reg, String icon) {
+		Path iconPath = new Path("resources/"+icon+".png");
+		URL iconURL = FileLocator.find(Activator.getDefault().getBundle(), iconPath, Collections.emptyMap());
+		reg.put(icon, ImageDescriptor.createFromURL(iconURL));
 	}
 }


### PR DESCRIPTION
- use Eclipse ImageRegistry to save resources and simplify code

![image](https://cloud.githubusercontent.com/assets/1105127/24000011/527a05d6-0a5a-11e7-8a21-63cfda69907f.png)
