### PR TITLE
WidgetLookup may fail on widget disposed

### DIFF
--- a/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/WidgetLookup.java
+++ b/plugins/org.jboss.reddeer.core/src/org/jboss/reddeer/core/lookup/WidgetLookup.java
@@ -16,6 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.widgets.Control;
@@ -356,7 +357,16 @@ public class WidgetLookup {
 
 				@Override
 				public List<Widget> run() {
-					return WidgetResolver.getInstance().getChildren(parentWidget);
+					List<Widget> children = null;
+					try{
+						children = WidgetResolver.getInstance().getChildren(parentWidget);
+					} catch (SWTException e) {
+						if(!parentWidget.isDisposed()){
+							throw e;
+						}
+						//otherwise ok, parentWidget is disposed so it has no children
+					}
+					return children;
 				}
 			});
 			controls.addAll(findControlsUI(children, matcher, recursive));


### PR DESCRIPTION
`org.jboss.reddeer.common.exception.RedDeerException: Exception during sync execution in UI thread
	at org.jboss.reddeer.common.util.Display.handleErrorOccured(Display.java:111)
	at org.jboss.reddeer.common.util.Display.syncExec(Display.java:83)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:355)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:411)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControlsUI(WidgetLookup.java:362)
	at org.jboss.reddeer.core.lookup.WidgetLookup.findControls(WidgetLookup.java:285)
	at org.jboss.reddeer.core.lookup.WidgetLookup.activeWidgets(WidgetLookup.java:172)
	at org.jboss.reddeer.core.lookup.WidgetLookup.activeWidgets(WidgetLookup.java:131)
	at org.jboss.reddeer.workbench.impl.view.AbstractView.isOpened(AbstractView.java:258)
	at org.jboss.reddeer.workbench.impl.view.AbstractView.getViewCTabItem(AbstractView.java:128)
	at org.jboss.reddeer.workbench.impl.view.AbstractView.<init>(AbstractView.java:84)
	at org.jboss.reddeer.workbench.impl.view.AbstractView.<init>(AbstractView.java:71)
	at org.jboss.reddeer.workbench.impl.view.WorkbenchView.<init>(WorkbenchView.java:31)
	at org.jboss.reddeer.eclipse.wst.server.ui.cnf.ServersView2.<init>(ServersView2.java:45)
	at org.jboss.reddeer.eclipse.condition.ServerExists.<init>(ServerExists.java:39)
	at org.jboss.reddeer.eclipse.wst.server.ui.cnf.AbstractServer.delete(AbstractServer.java:220)
	at org.jboss.reddeer.eclipse.test.wst.server.ui.view.ServersViewTestCase.deleteServers(ServersViewTestCase.java:55)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.jboss.reddeer.junit.internal.runner.statement.RunAfters.evaluate(RunAfters.java:77)
	at org.jboss.reddeer.junit.internal.runner.statement.CleanUpRequirementStatement.evaluate(CleanUpRequirementStatement.java:44)
	at org.jboss.reddeer.junit.internal.runner.statement.RunIAfterClassExtensions.evaluate(RunIAfterClassExtensions.java:56)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.jboss.reddeer.junit.internal.runner.RequirementsRunner.run(RequirementsRunner.java:154)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:208)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:156)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:82)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:95)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.runTests(AbstractUITestApplication.java:44)
	at org.eclipse.e4.ui.internal.workbench.swt.E4Testable$1.run(E4Testable.java:73)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4533)
	at org.eclipse.swt.SWT.error(SWT.java:4448)
	at org.eclipse.swt.SWT.error(SWT.java:4419)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:482)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:354)
	at org.eclipse.swt.widgets.Composite.getChildren(Composite.java:489)
	at org.jboss.reddeer.core.resolver.WidgetResolver.getChildren(WidgetResolver.java:199)
	at org.jboss.reddeer.core.lookup.WidgetLookup$2.run(WidgetLookup.java:359)
	at org.jboss.reddeer.core.lookup.WidgetLookup$2.run(WidgetLookup.java:1)
	at org.jboss.reddeer.common.util.Display$ErrorHandlingRunnable.run(Display.java:161)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:35)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:182)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4211)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3827)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1121)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1022)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:150)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:693)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:610)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:138)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.runApplication(UITestApplication.java:31)
	at org.eclipse.tycho.surefire.osgibooter.AbstractUITestApplication.run(AbstractUITestApplication.java:120)
	at org.eclipse.tycho.surefire.osgibooter.UITestApplication.start(UITestApplication.java:37)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:673)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:610)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1519)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1492)`